### PR TITLE
Feature/upload imagem exame

### DIFF
--- a/src/api/routes/exams.ts
+++ b/src/api/routes/exams.ts
@@ -2,6 +2,7 @@ import type { FastifyInstance } from 'fastify';
 import { authenticationMiddleware, authorizationMiddleware } from '../middlewares';
 import { tiposPerfil } from '@/modules/users/domain';
 import { createExam } from './exams/create-exam';
+import { uploadExamImages } from './exams/upload-exam-images';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function examRoutes(app: FastifyInstance): Promise<void> {
@@ -9,5 +10,11 @@ export async function examRoutes(app: FastifyInstance): Promise<void> {
     '/exams',
     { preHandler: [authenticationMiddleware, authorizationMiddleware([tiposPerfil.MEDICO])] },
     createExam,
+  );
+
+  app.post<{ Params: { examId: string } }>(
+    '/exams/:examId/images',
+    { preHandler: [authenticationMiddleware, authorizationMiddleware([tiposPerfil.MEDICO])] },
+    uploadExamImages,
   );
 }

--- a/src/api/routes/exams/upload-exam-images.ts
+++ b/src/api/routes/exams/upload-exam-images.ts
@@ -1,0 +1,79 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { container } from '@/infra/container';
+import { ValidationError } from '@/shared/errors';
+import { LateralidadeOlho } from '@/modules/exam/imagem';
+import type {
+  UploadExamImageInput,
+  UploadExamImagesUseCase,
+} from '@/modules/exam/use-cases/upload-exam-images-usecase';
+
+const FIELD_TO_LATERALIDADE: Record<string, LateralidadeOlho | undefined> = {
+  olhoDireito: LateralidadeOlho.OD,
+  olhoEsquerdo: LateralidadeOlho.OE,
+};
+
+const MIME_TO_EXTENSION = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+} as const satisfies Record<string, UploadExamImageInput['extension']>;
+
+type AllowedMime = keyof typeof MIME_TO_EXTENSION;
+
+const isAllowedMime = (mime: string): mime is AllowedMime => mime in MIME_TO_EXTENSION;
+
+export async function uploadExamImages(
+  request: FastifyRequest<{ Params: { examId: string } }>,
+  reply: FastifyReply,
+) {
+  const { examId } = request.params;
+  const imagens: UploadExamImageInput[] = [];
+
+  for await (const part of request.parts()) {
+    if (part.type !== 'file') continue;
+
+    const lateralidade = FIELD_TO_LATERALIDADE[part.fieldname];
+    if (!lateralidade) {
+      throw new ValidationError(
+        [{ path: [part.fieldname], message: 'Campo de arquivo inválido.' }],
+        true,
+      );
+    }
+
+    if (!isAllowedMime(part.mimetype)) {
+      throw new ValidationError(
+        [{ path: [part.fieldname], message: 'Formato de imagem inválido.' }],
+        true,
+      );
+    }
+
+    if (imagens.some((img) => img.lateralidade === lateralidade)) {
+      throw new ValidationError(
+        [{ path: [part.fieldname], message: 'Arquivo duplicado para o mesmo olho.' }],
+        true,
+      );
+    }
+
+    imagens.push({
+      lateralidade,
+      buffer: await part.toBuffer(),
+      contentType: part.mimetype,
+      extension: MIME_TO_EXTENSION[part.mimetype],
+    });
+  }
+
+  if (imagens.length === 0) {
+    throw new ValidationError(
+      [{ path: ['imagens'], message: 'Envie pelo menos uma imagem' }],
+      true,
+    );
+  }
+
+  const usecase: UploadExamImagesUseCase = container.resolve('uploadExamImagesUseCase');
+  const response = await usecase.execute({
+    examId,
+    userId: request.user!.id,
+    imagens,
+  });
+
+  return reply.status(201).send(response);
+}

--- a/src/infra/container/index.ts
+++ b/src/infra/container/index.ts
@@ -3,6 +3,7 @@ import {
   DrizzleSolicitacaoCpfCrmRepository,
   DrizzleUsuariosRepository,
   DrizzleExamesRepository,
+  DrizzleImagemRepository,
 } from '@/infra/database/drizzle/repositories';
 import { BetterAuthService } from '@/infra/auth/better-auth-service';
 import { MinioStorageService } from '@/infra/storage/minio-storage-service';
@@ -17,7 +18,9 @@ import { RejeitarSolicitacaoCpfCrmUsecase } from '@/modules/users/use-cases/reje
 import { ListarSolicitacoesCpfCrmUsecase } from '@/modules/users/use-cases/listar-solicitacoes-cpf-crm';
 import type { UsuariosRepository, SolicitacaoCpfCrmRepository } from '@/modules/users/repositories';
 import { CreateExamUseCase } from '@/modules/exam/use-cases/create-exam-usecase';
+import { UploadExamImagesUseCase } from '@/modules/exam/use-cases/upload-exam-images-usecase';
 import type { ExamesRepository } from '@/modules/exam/exam-repository';
+import type { ImagemRepository } from '@/modules/exam/imagem-repository';
 import type { AuthService } from '@/shared/services/auth-service';
 import type { StorageService } from '@/shared/services/storage-service';
 import type { CryptographyService } from '@/shared/services/cryptography-service';
@@ -27,6 +30,7 @@ export interface AppContainer {
   usuariosRepository: UsuariosRepository;
   solicitacaoCpfCrmRepository: SolicitacaoCpfCrmRepository;
   examesRepository: ExamesRepository;
+  imagemRepository: ImagemRepository;
   authService: AuthService;
   storageService: StorageService;
   cryptographyService: CryptographyService;
@@ -39,6 +43,7 @@ export interface AppContainer {
   rejeitarSolicitacaoCpfCrmUsecase: RejeitarSolicitacaoCpfCrmUsecase;
   listarSolicitacoesCpfCrmUsecase: ListarSolicitacoesCpfCrmUsecase;
   createExamUseCase: CreateExamUseCase;
+  uploadExamImagesUseCase: UploadExamImagesUseCase;
 }
 
 export const container: AwilixContainer<AppContainer> = createContainer<AppContainer>({
@@ -50,6 +55,7 @@ container.register({
   usuariosRepository: asClass(DrizzleUsuariosRepository).singleton(),
   solicitacaoCpfCrmRepository: asClass(DrizzleSolicitacaoCpfCrmRepository).singleton(),
   examesRepository: asClass(DrizzleExamesRepository).singleton(),
+  imagemRepository: asClass(DrizzleImagemRepository).singleton(),
   authService: asClass(BetterAuthService).singleton(),
   storageService: asClass(MinioStorageService).singleton(),
   cryptographyService: asClass(NodeCryptoCryptographyService).singleton(),
@@ -89,5 +95,9 @@ container.register({
         cryptographyService,
         maskingService,
       ),
+  ).scoped(),
+  uploadExamImagesUseCase: asFunction(
+    ({ examesRepository, imagemRepository, storageService }: AppContainer) =>
+      new UploadExamImagesUseCase(examesRepository, imagemRepository, storageService),
   ).scoped(),
 });

--- a/src/infra/database/drizzle/migrations/0003_create_imagem_table.sql
+++ b/src/infra/database/drizzle/migrations/0003_create_imagem_table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE "imagem" (
+	"id_imagem" uuid PRIMARY KEY NOT NULL,
+	"id_exame" uuid NOT NULL,
+	"lateralidade_olho" varchar(20) NOT NULL,
+	"caminho_img" varchar(255) NOT NULL,
+	"qualidade_img" varchar(50) DEFAULT 'Pendente' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "imagem" ADD CONSTRAINT "imagem_id_exame_exame_id_exame_fk" FOREIGN KEY ("id_exame") REFERENCES "public"."exame"("id_exame") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "imagem_id_exame_lateralidade_uq" ON "imagem" USING btree ("id_exame","lateralidade_olho");--> statement-breakpoint
+CREATE INDEX "imagem_id_exame_idx" ON "imagem" USING btree ("id_exame");

--- a/src/infra/database/drizzle/migrations/meta/0003_snapshot.json
+++ b/src/infra/database/drizzle/migrations/meta/0003_snapshot.json
@@ -1,0 +1,841 @@
+{
+  "id": "4077dfc2-7d7c-488c-8f6d-f92ba06a2cb5",
+  "prevId": "9275c618-ef9c-45c7-8e16-445a2f7d71a2",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "account_user_id_idx": {
+          "name": "account_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_usuario_id_usuario_fk": {
+          "name": "account_user_id_usuario_id_usuario_fk",
+          "tableFrom": "account",
+          "tableTo": "usuario",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id_usuario"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "session_user_id_idx": {
+          "name": "session_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_usuario_id_usuario_fk": {
+          "name": "session_user_id_usuario_id_usuario_fk",
+          "tableFrom": "session",
+          "tableTo": "usuario",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id_usuario"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solicitacao_cpf_crm": {
+      "name": "solicitacao_cpf_crm",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id_usuario": {
+          "name": "id_usuario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpf_novo": {
+          "name": "cpf_novo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crm_novo": {
+          "name": "crm_novo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "solicitacao_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDENTE'"
+        },
+        "motivo_rejeicao": {
+          "name": "motivo_rejeicao",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analisado_por": {
+          "name": "analisado_por",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "analisado_em": {
+          "name": "analisado_em",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "solicitacao_usuario_idx": {
+          "name": "solicitacao_usuario_idx",
+          "columns": [
+            {
+              "expression": "id_usuario",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "solicitacao_status_idx": {
+          "name": "solicitacao_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "solicitacao_usuario_status_idx": {
+          "name": "solicitacao_usuario_status_idx",
+          "columns": [
+            {
+              "expression": "id_usuario",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "solicitacao_cpf_crm_id_usuario_usuario_id_usuario_fk": {
+          "name": "solicitacao_cpf_crm_id_usuario_usuario_id_usuario_fk",
+          "tableFrom": "solicitacao_cpf_crm",
+          "tableTo": "usuario",
+          "columnsFrom": [
+            "id_usuario"
+          ],
+          "columnsTo": [
+            "id_usuario"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "solicitacao_cpf_crm_analisado_por_usuario_id_usuario_fk": {
+          "name": "solicitacao_cpf_crm_analisado_por_usuario_id_usuario_fk",
+          "tableFrom": "solicitacao_cpf_crm",
+          "tableTo": "usuario",
+          "columnsFrom": [
+            "analisado_por"
+          ],
+          "columnsTo": [
+            "id_usuario"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usuario": {
+      "name": "usuario",
+      "schema": "",
+      "columns": {
+        "id_usuario": {
+          "name": "id_usuario",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "nome_completo": {
+          "name": "nome_completo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dt_nascimento": {
+          "name": "dt_nascimento",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crm": {
+          "name": "crm",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tipo_perfil": {
+          "name": "tipo_perfil",
+          "type": "tipo_perfil",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'MEDICO'"
+        },
+        "status": {
+          "name": "status",
+          "type": "status_usuario",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'ATIVO'"
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "usuario_email_unique": {
+          "name": "usuario_email_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usuario_cpf_unique": {
+          "name": "usuario_cpf_unique",
+          "columns": [
+            {
+              "expression": "cpf",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "usuario_crm_unique": {
+          "name": "usuario_crm_unique",
+          "columns": [
+            {
+              "expression": "crm",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            {
+              "expression": "identifier",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.exame": {
+      "name": "exame",
+      "schema": "",
+      "columns": {
+        "id_exame": {
+          "name": "id_exame",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id_usuario": {
+          "name": "id_usuario",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nome_completo": {
+          "name": "nome_completo",
+          "type": "varchar(150)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "varchar(14)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_nascimento": {
+          "name": "data_nascimento",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sexo": {
+          "name": "sexo",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_hora": {
+          "name": "data_hora",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comorbidades": {
+          "name": "comorbidades",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "descricao": {
+          "name": "descricao",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "exame_id_usuario_usuario_id_usuario_fk": {
+          "name": "exame_id_usuario_usuario_id_usuario_fk",
+          "tableFrom": "exame",
+          "tableTo": "usuario",
+          "columnsFrom": [
+            "id_usuario"
+          ],
+          "columnsTo": [
+            "id_usuario"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.imagem": {
+      "name": "imagem",
+      "schema": "",
+      "columns": {
+        "id_imagem": {
+          "name": "id_imagem",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "id_exame": {
+          "name": "id_exame",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lateralidade_olho": {
+          "name": "lateralidade_olho",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "caminho_img": {
+          "name": "caminho_img",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "qualidade_img": {
+          "name": "qualidade_img",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Pendente'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "imagem_id_exame_lateralidade_uq": {
+          "name": "imagem_id_exame_lateralidade_uq",
+          "columns": [
+            {
+              "expression": "id_exame",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lateralidade_olho",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "imagem_id_exame_idx": {
+          "name": "imagem_id_exame_idx",
+          "columns": [
+            {
+              "expression": "id_exame",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "imagem_id_exame_exame_id_exame_fk": {
+          "name": "imagem_id_exame_exame_id_exame_fk",
+          "tableFrom": "imagem",
+          "tableTo": "exame",
+          "columnsFrom": [
+            "id_exame"
+          ],
+          "columnsTo": [
+            "id_exame"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.solicitacao_status": {
+      "name": "solicitacao_status",
+      "schema": "public",
+      "values": [
+        "PENDENTE",
+        "APROVADA",
+        "REJEITADA"
+      ]
+    },
+    "public.status_usuario": {
+      "name": "status_usuario",
+      "schema": "public",
+      "values": [
+        "ATIVO",
+        "INATIVO",
+        "BLOQUEADO"
+      ]
+    },
+    "public.tipo_perfil": {
+      "name": "tipo_perfil",
+      "schema": "public",
+      "values": [
+        "ADMIN",
+        "MEDICO"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/infra/database/drizzle/migrations/meta/_journal.json
+++ b/src/infra/database/drizzle/migrations/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777154606018,
       "tag": "0002_add_crm_and_cpf_solicitation_table",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777819744987,
+      "tag": "0003_create_imagem_table",
+      "breakpoints": true
     }
   ]
 }

--- a/src/infra/database/drizzle/repositories/drizzle-exame-repository.ts
+++ b/src/infra/database/drizzle/repositories/drizzle-exame-repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, type SQL } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 
 import { db } from '@/infra/database/drizzle/connection';
 import { exam } from '@/infra/database/drizzle/schema';
@@ -38,16 +38,7 @@ export class DrizzleExamesRepository implements ExamesRepository {
   }
 
   async findOne({ examId }: FindExameInput): Promise<Exame | null> {
-    const conditions: SQL[] = [];
-    if (examId !== undefined) conditions.push(eq(exam.idExame, examId));
-
-    if (conditions.length === 0) return null;
-
-    const rows = await db
-      .select()
-      .from(exam)
-      .where(and(...conditions))
-      .limit(1);
+    const rows = await db.select().from(exam).where(eq(exam.idExame, examId)).limit(1);
 
     if (rows.length === 0) return null;
 

--- a/src/infra/database/drizzle/repositories/drizzle-exame-repository.ts
+++ b/src/infra/database/drizzle/repositories/drizzle-exame-repository.ts
@@ -1,7 +1,9 @@
+import { and, eq, type SQL } from 'drizzle-orm';
+
 import { db } from '@/infra/database/drizzle/connection';
 import { exam } from '@/infra/database/drizzle/schema';
 import type { Exame, ExameStatus, Sexo } from '@/modules/exam/exam';
-import type { ExamesRepository } from '@/modules/exam/exam-repository';
+import type { ExamesRepository, FindExameInput } from '@/modules/exam/exam-repository';
 
 export class DrizzleExamesRepository implements ExamesRepository {
   async create(input: Exame): Promise<Exame> {
@@ -21,6 +23,35 @@ export class DrizzleExamesRepository implements ExamesRepository {
       })
       .returning();
 
+    return {
+      id: row.idExame,
+      idUsuario: row.idUsuario,
+      nomeCompleto: row.nomeCompleto,
+      cpf: row.cpf,
+      dtNascimento: row.dtNascimento,
+      sexo: row.sexo as Sexo,
+      dtHora: row.dtHora,
+      status: row.status as ExameStatus,
+      comorbidades: row.comorbidades,
+      descricao: row.descricao,
+    };
+  }
+
+  async findOne({ examId }: FindExameInput): Promise<Exame | null> {
+    const conditions: SQL[] = [];
+    if (examId !== undefined) conditions.push(eq(exam.idExame, examId));
+
+    if (conditions.length === 0) return null;
+
+    const rows = await db
+      .select()
+      .from(exam)
+      .where(and(...conditions))
+      .limit(1);
+
+    if (rows.length === 0) return null;
+
+    const [row] = rows;
     return {
       id: row.idExame,
       idUsuario: row.idUsuario,

--- a/src/infra/database/drizzle/repositories/drizzle-imagem-repository.ts
+++ b/src/infra/database/drizzle/repositories/drizzle-imagem-repository.ts
@@ -1,0 +1,54 @@
+import { and, eq, type SQL } from 'drizzle-orm';
+
+import { db } from '@/infra/database/drizzle/connection';
+import { imagem } from '@/infra/database/drizzle/schema';
+import type { Imagem, LateralidadeOlho } from '@/modules/exam/imagem';
+import type { FindImagensInput, ImagemRepository } from '@/modules/exam/imagem-repository';
+
+export class DrizzleImagemRepository implements ImagemRepository {
+  async findMany({ examId }: FindImagensInput): Promise<Imagem[]> {
+    const conditions: SQL[] = [];
+    if (examId !== undefined) conditions.push(eq(imagem.idExame, examId));
+
+    const rows =
+      conditions.length > 0
+        ? await db
+            .select()
+            .from(imagem)
+            .where(and(...conditions))
+        : await db.select().from(imagem);
+
+    return rows.map((row) => ({
+      id: row.idImagem,
+      idExame: row.idExame,
+      lateralidadeOlho: row.lateralidadeOlho as LateralidadeOlho,
+      caminhoImg: row.caminhoImg,
+      qualidadeImg: row.qualidadeImg,
+    }));
+  }
+
+  async createMany(imagens: Imagem[]): Promise<Imagem[]> {
+    if (imagens.length === 0) return [];
+
+    const rows = await db
+      .insert(imagem)
+      .values(
+        imagens.map((img) => ({
+          idImagem: img.id,
+          idExame: img.idExame,
+          lateralidadeOlho: img.lateralidadeOlho,
+          caminhoImg: img.caminhoImg,
+          qualidadeImg: img.qualidadeImg,
+        })),
+      )
+      .returning();
+
+    return rows.map((row) => ({
+      id: row.idImagem,
+      idExame: row.idExame,
+      lateralidadeOlho: row.lateralidadeOlho as LateralidadeOlho,
+      caminhoImg: row.caminhoImg,
+      qualidadeImg: row.qualidadeImg,
+    }));
+  }
+}

--- a/src/infra/database/drizzle/repositories/drizzle-imagem-repository.ts
+++ b/src/infra/database/drizzle/repositories/drizzle-imagem-repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, type SQL } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 
 import { db } from '@/infra/database/drizzle/connection';
 import { imagem } from '@/infra/database/drizzle/schema';
@@ -7,16 +7,7 @@ import type { FindImagensInput, ImagemRepository } from '@/modules/exam/imagem-r
 
 export class DrizzleImagemRepository implements ImagemRepository {
   async findMany({ examId }: FindImagensInput): Promise<Imagem[]> {
-    const conditions: SQL[] = [];
-    if (examId !== undefined) conditions.push(eq(imagem.idExame, examId));
-
-    const rows =
-      conditions.length > 0
-        ? await db
-            .select()
-            .from(imagem)
-            .where(and(...conditions))
-        : await db.select().from(imagem);
+    const rows = await db.select().from(imagem).where(eq(imagem.idExame, examId));
 
     return rows.map((row) => ({
       id: row.idImagem,

--- a/src/infra/database/drizzle/repositories/index.ts
+++ b/src/infra/database/drizzle/repositories/index.ts
@@ -1,3 +1,4 @@
 export * from './drizzle-usuario-repository';
 export * from './drizzle-solicitacao-repository';
 export * from './drizzle-exame-repository';
+export * from './drizzle-imagem-repository';

--- a/src/infra/database/drizzle/schema/exam.ts
+++ b/src/infra/database/drizzle/schema/exam.ts
@@ -2,6 +2,7 @@ import { pgTable, text, timestamp, varchar, uuid } from 'drizzle-orm/pg-core';
 import { relations } from 'drizzle-orm';
 
 import { usuario } from './user';
+import { imagem } from './image';
 
 export const exam = pgTable('exame', {
   idExame: uuid('id_exame').primaryKey(),
@@ -23,9 +24,10 @@ export const exam = pgTable('exame', {
     .notNull(),
 });
 
-export const examRelations = relations(exam, ({ one }) => ({
+export const examRelations = relations(exam, ({ one, many }) => ({
   usuario: one(usuario, {
     fields: [exam.idUsuario],
     references: [usuario.id],
   }),
+  imagens: many(imagem),
 }));

--- a/src/infra/database/drizzle/schema/image.ts
+++ b/src/infra/database/drizzle/schema/image.ts
@@ -1,0 +1,33 @@
+import { pgTable, timestamp, varchar, uuid, uniqueIndex, index } from 'drizzle-orm/pg-core';
+import { relations } from 'drizzle-orm';
+
+import { exam } from './exam';
+
+export const imagem = pgTable(
+  'imagem',
+  {
+    idImagem: uuid('id_imagem').primaryKey(),
+    idExame: uuid('id_exame')
+      .notNull()
+      .references(() => exam.idExame, { onDelete: 'cascade' }),
+    lateralidadeOlho: varchar('lateralidade_olho', { length: 20 }).notNull(),
+    caminhoImg: varchar('caminho_img', { length: 255 }).notNull(),
+    qualidadeImg: varchar('qualidade_img', { length: 50 }).default('Pendente').notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at')
+      .defaultNow()
+      .$onUpdate(() => new Date())
+      .notNull(),
+  },
+  (table) => [
+    uniqueIndex('imagem_id_exame_lateralidade_uq').on(table.idExame, table.lateralidadeOlho),
+    index('imagem_id_exame_idx').on(table.idExame),
+  ],
+);
+
+export const imagemRelations = relations(imagem, ({ one }) => ({
+  exame: one(exam, {
+    fields: [imagem.idExame],
+    references: [exam.idExame],
+  }),
+}));

--- a/src/infra/database/drizzle/schema/index.ts
+++ b/src/infra/database/drizzle/schema/index.ts
@@ -1,2 +1,3 @@
 export * from './user';
 export * from './exam';
+export * from './image';

--- a/src/infra/storage/bucket-access.ts
+++ b/src/infra/storage/bucket-access.ts
@@ -4,4 +4,5 @@ export type BucketAccess = 'public' | 'private';
 
 export const bucketAccess: Record<BucketName, BucketAccess> = {
   [Buckets.userImages]: 'public',
+  [Buckets.examImages]: 'private',
 };

--- a/src/infra/storage/minio-storage-service.ts
+++ b/src/infra/storage/minio-storage-service.ts
@@ -12,11 +12,21 @@ export class MinioStorageService implements StorageService {
     return `${baseUrl}/${bucket}/${input.key}`;
   }
 
+  async uploadPrivate(input: UploadInput, bucket: BucketName): Promise<void> {
+    await minioClient.putObject(bucket, input.key, input.buffer, input.buffer.length, {
+      'Content-Type': input.contentType,
+    });
+  }
+
   async deleteByUrl(url: string, bucket: BucketName): Promise<void> {
     const { pathname } = new URL(url);
     const bucketPath = `/${bucket}/`;
     const key = pathname.slice(pathname.indexOf(bucketPath) + bucketPath.length);
 
+    await minioClient.removeObject(bucket, key);
+  }
+
+  async deleteByKey(key: string, bucket: BucketName): Promise<void> {
     await minioClient.removeObject(bucket, key);
   }
 }

--- a/src/modules/exam/exam-repository.ts
+++ b/src/modules/exam/exam-repository.ts
@@ -1,5 +1,10 @@
 import type { Exame } from './exam';
 
-export interface ExamesRepository {
+export type FindExameInput = {
+  examId?: string;
+};
+
+export type ExamesRepository = {
   create(input: Exame): Promise<Exame>;
-}
+  findOne(input: FindExameInput): Promise<Exame | null>;
+};

--- a/src/modules/exam/exam-repository.ts
+++ b/src/modules/exam/exam-repository.ts
@@ -1,7 +1,7 @@
 import type { Exame } from './exam';
 
 export type FindExameInput = {
-  examId?: string;
+  examId: string;
 };
 
 export type ExamesRepository = {

--- a/src/modules/exam/imagem-repository.ts
+++ b/src/modules/exam/imagem-repository.ts
@@ -1,0 +1,10 @@
+import type { Imagem } from './imagem';
+
+export type FindImagensInput = {
+  examId?: string;
+};
+
+export type ImagemRepository = {
+  findMany(input: FindImagensInput): Promise<Imagem[]>;
+  createMany(imagens: Imagem[]): Promise<Imagem[]>;
+};

--- a/src/modules/exam/imagem-repository.ts
+++ b/src/modules/exam/imagem-repository.ts
@@ -1,7 +1,7 @@
 import type { Imagem } from './imagem';
 
 export type FindImagensInput = {
-  examId?: string;
+  examId: string;
 };
 
 export type ImagemRepository = {

--- a/src/modules/exam/imagem.ts
+++ b/src/modules/exam/imagem.ts
@@ -1,0 +1,19 @@
+export type Imagem = {
+  id: string;
+  idExame: string;
+  lateralidadeOlho: LateralidadeOlho;
+  caminhoImg: string;
+  qualidadeImg: string;
+};
+
+export const LateralidadeOlho = {
+  OD: 'OD',
+  OE: 'OE',
+} as const;
+
+export const QualidadeImagem = {
+  Pendente: 'Pendente',
+} as const;
+
+export type LateralidadeOlho = keyof typeof LateralidadeOlho;
+export type QualidadeImagem = keyof typeof QualidadeImagem;

--- a/src/modules/exam/index.ts
+++ b/src/modules/exam/index.ts
@@ -1,2 +1,4 @@
 export * from './exam';
 export * from './exam-repository';
+export * from './imagem';
+export * from './imagem-repository';

--- a/src/modules/exam/use-cases/upload-exam-images-usecase.ts
+++ b/src/modules/exam/use-cases/upload-exam-images-usecase.ts
@@ -1,0 +1,145 @@
+import { randomUUID } from 'node:crypto';
+import type { Exame } from '@/modules/exam/exam';
+import type { ExamesRepository } from '@/modules/exam/exam-repository';
+import type { ImagemRepository } from '@/modules/exam/imagem-repository';
+import { QualidadeImagem, type Imagem, type LateralidadeOlho } from '@/modules/exam/imagem';
+import { Buckets, type StorageService } from '@/shared/services';
+import { ConflictError, NotFoundError } from '@/shared/errors';
+import logger from '@/infra/logger';
+
+export interface UploadExamImageInput {
+  lateralidade: LateralidadeOlho;
+  buffer: Buffer;
+  contentType: 'image/jpeg' | 'image/png';
+  extension: 'jpg' | 'jpeg' | 'png';
+}
+
+export interface UploadExamImagesUseCaseInput {
+  examId: string;
+  userId: string;
+  imagens: UploadExamImageInput[];
+}
+
+export interface UploadedImagemDto {
+  id: string;
+  idExame: string;
+  lateralidadeOlho: LateralidadeOlho;
+  qualidadeImg: string;
+}
+
+export interface UploadExamImagesUseCaseOutput {
+  imagens: UploadedImagemDto[];
+}
+
+function toUploadedImagemDto(imagem: Imagem): UploadedImagemDto {
+  return {
+    id: imagem.id,
+    idExame: imagem.idExame,
+    lateralidadeOlho: imagem.lateralidadeOlho,
+    qualidadeImg: imagem.qualidadeImg,
+  };
+}
+
+interface ImageUploadItem {
+  id: string;
+  lateralidade: LateralidadeOlho;
+  objectKey: string;
+  buffer: Buffer;
+  contentType: string;
+}
+
+export class UploadExamImagesUseCase {
+  constructor(
+    private readonly examRepository: ExamesRepository,
+    private readonly imagemRepository: ImagemRepository,
+    private readonly storageService: StorageService,
+  ) {}
+
+  async execute(input: UploadExamImagesUseCaseInput): Promise<UploadExamImagesUseCaseOutput> {
+    const { examId, userId, imagens } = input;
+
+    const exame = await this.getExam(examId);
+    this.assertOwnership(exame, userId);
+    await this.assertNoImages(examId);
+
+    const prepared = this.buildImagePayloads(examId, imagens);
+    await this.uploadAll(prepared);
+
+    const created = await this.createImages(examId, prepared);
+    return { imagens: created.map(toUploadedImagemDto) };
+  }
+
+  private async getExam(examId: string): Promise<Exame> {
+    const exame = await this.examRepository.findOne({ examId });
+
+    if (!exame) {
+      throw new NotFoundError('O exame não existe');
+    }
+
+    return exame;
+  }
+
+  private assertOwnership(exame: Exame, userId: string): void {
+    if (exame.idUsuario !== userId) {
+      logger.warn('User is not the owner of the exam', { userId, examId: exame.id });
+      throw new NotFoundError('O exame não existe');
+    }
+  }
+
+  private async assertNoImages(examId: string): Promise<void> {
+    const existing = await this.imagemRepository.findMany({ examId });
+
+    if (existing.length > 0) {
+      throw new ConflictError('O exame já possui imagens');
+    }
+  }
+
+  private buildImagePayloads(examId: string, imagens: UploadExamImageInput[]): ImageUploadItem[] {
+    return imagens.map((img) => {
+      const id = randomUUID();
+      return {
+        id,
+        lateralidade: img.lateralidade,
+        objectKey: `exams/${examId}/${img.lateralidade}-${id}.${img.extension}`,
+        buffer: img.buffer,
+        contentType: img.contentType,
+      };
+    });
+  }
+
+  private async uploadAll(prepared: ImageUploadItem[]): Promise<void> {
+    const uploadedKeys: string[] = [];
+
+    try {
+      for (const item of prepared) {
+        await this.storageService.uploadPrivate(
+          { key: item.objectKey, buffer: item.buffer, contentType: item.contentType },
+          Buckets.examImages,
+        );
+        uploadedKeys.push(item.objectKey);
+      }
+    } catch (error) {
+      logger.error('Error while uploading exam images, starting rollback', { error });
+      await this.rollback(uploadedKeys);
+      throw error;
+    }
+  }
+
+  private async rollback(keys: string[]): Promise<void> {
+    for (const key of keys) {
+      await this.storageService.deleteByKey(key, Buckets.examImages);
+    }
+  }
+
+  private async createImages(examId: string, prepared: ImageUploadItem[]): Promise<Imagem[]> {
+    const images: Imagem[] = prepared.map((item) => ({
+      id: item.id,
+      idExame: examId,
+      lateralidadeOlho: item.lateralidade,
+      caminhoImg: item.objectKey,
+      qualidadeImg: QualidadeImagem.Pendente,
+    }));
+
+    return this.imagemRepository.createMany(images);
+  }
+}

--- a/src/shared/errors/index.ts
+++ b/src/shared/errors/index.ts
@@ -3,3 +3,4 @@ export * from './not-found-error';
 export * from './unauthorized-error';
 export * from './authentication-error';
 export * from './validation-error';
+export * from './conflict-error';

--- a/src/shared/services/storage-service.ts
+++ b/src/shared/services/storage-service.ts
@@ -1,5 +1,6 @@
 export const Buckets = {
   userImages: 'user-images',
+  examImages: 'exam-images',
 } as const;
 
 export type BucketName = (typeof Buckets)[keyof typeof Buckets];
@@ -12,5 +13,7 @@ export interface UploadInput {
 
 export interface StorageService {
   upload(input: UploadInput, bucket: BucketName): Promise<string>;
+  uploadPrivate(input: UploadInput, bucket: BucketName): Promise<void>;
   deleteByUrl(url: string, bucket: BucketName): Promise<void>;
+  deleteByKey(key: string, bucket: BucketName): Promise<void>;
 }

--- a/src/tests/helpers/builders/imagem-builder.ts
+++ b/src/tests/helpers/builders/imagem-builder.ts
@@ -1,0 +1,84 @@
+import { faker } from '@faker-js/faker';
+import { eq } from 'drizzle-orm';
+import { db } from '@/infra/database/drizzle/connection';
+import { exam, imagem } from '@/infra/database/drizzle/schema';
+import { LateralidadeOlho, QualidadeImagem, type Imagem } from '@/modules/exam/imagem';
+import { ExameBuilder } from './exame-builder';
+
+export class ImagemBuilder {
+  private readonly data: Imagem;
+  private readonly database: typeof db;
+
+  private constructor() {
+    this.database = db;
+    const id = faker.string.uuid();
+    const idExame = faker.string.uuid();
+    this.data = {
+      id: faker.string.uuid(),
+      idExame: faker.string.uuid(),
+      lateralidadeOlho: LateralidadeOlho.OD,
+      caminhoImg: `exams/${idExame}/${LateralidadeOlho.OD}-${id}.jpg`,
+      qualidadeImg: QualidadeImagem.Pendente,
+    };
+  }
+
+  public withId(id: string): this {
+    this.data.id = id;
+    return this;
+  }
+
+  public withIdExame(idExame: string): this {
+    this.data.idExame = idExame;
+    return this;
+  }
+
+  public withLateralidadeOlho(lateralidadeOlho: LateralidadeOlho): this {
+    this.data.lateralidadeOlho = lateralidadeOlho;
+    return this;
+  }
+
+  public withCaminhoImg(caminhoImg: string): this {
+    this.data.caminhoImg = caminhoImg;
+    return this;
+  }
+
+  public withQualidadeImg(qualidadeImg: string): this {
+    this.data.qualidadeImg = qualidadeImg;
+    return this;
+  }
+
+  public static anImagem(): ImagemBuilder {
+    return new ImagemBuilder();
+  }
+
+  public async build(): Promise<Imagem> {
+    await this.ensureExame();
+
+    await this.database.insert(imagem).values({
+      idImagem: this.data.id,
+      idExame: this.data.idExame,
+      lateralidadeOlho: this.data.lateralidadeOlho,
+      caminhoImg: this.data.caminhoImg,
+      qualidadeImg: this.data.qualidadeImg,
+    });
+
+    return this.data;
+  }
+
+  private async ensureExame(): Promise<void> {
+    const existing = await this.database
+      .select({ id: exam.idExame })
+      .from(exam)
+      .where(eq(exam.idExame, this.data.idExame))
+      .limit(1);
+
+    if (existing.length) return;
+
+    const created = await ExameBuilder.anExame().build();
+    this.data.idExame = created.id;
+  }
+
+  public getData() {
+    return this.data;
+  }
+}

--- a/src/tests/helpers/multipart.ts
+++ b/src/tests/helpers/multipart.ts
@@ -38,3 +38,28 @@ export function buildEmptyMultipart(): MultipartPayload {
   const boundary = '----TestBoundaryEmpty';
   return buildPayload(boundary, Buffer.from(`--${boundary}--\r\n`));
 }
+
+export interface MultipartFilePart {
+  fieldName: string;
+  filename: string;
+  contentType: string;
+  buffer: Buffer;
+}
+
+export function buildMultipartFiles(parts: MultipartFilePart[]): MultipartPayload {
+  const boundary = `----TestBoundary${Date.now()}${randomBytes(8).toString('hex')}`;
+
+  const chunks: Buffer[] = [];
+  for (const part of parts) {
+    chunks.push(
+      Buffer.from(
+        `--${boundary}\r\nContent-Disposition: form-data; name="${part.fieldName}"; filename="${part.filename}"\r\nContent-Type: ${part.contentType}\r\n\r\n`,
+      ),
+      part.buffer,
+      Buffer.from('\r\n'),
+    );
+  }
+  chunks.push(Buffer.from(`--${boundary}--\r\n`));
+
+  return buildPayload(boundary, Buffer.concat(chunks));
+}

--- a/src/tests/integration/repositories/drizzle-imagem-repository.test.ts
+++ b/src/tests/integration/repositories/drizzle-imagem-repository.test.ts
@@ -1,0 +1,138 @@
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
+import { cpf as cpfUtil } from 'cpf-cnpj-validator';
+
+import { connectDatabase, db } from '@/infra/database/drizzle/connection';
+import { exam, imagem, usuario } from '@/infra/database/drizzle/schema';
+import { DrizzleImagemRepository } from '@/infra/database/drizzle/repositories/drizzle-imagem-repository';
+import { DrizzleExamesRepository } from '@/infra/database/drizzle/repositories/drizzle-exame-repository';
+import { ExameStatus, Sexo } from '@/modules/exam/exam';
+import { LateralidadeOlho } from '@/modules/exam/imagem';
+import { UsuarioBuilder } from '@/tests/helpers/builders/usuario-builder';
+
+describe('DrizzleImagemRepository (integration)', () => {
+  const repository = new DrizzleImagemRepository();
+  const examesRepository = new DrizzleExamesRepository();
+
+  beforeAll(async () => {
+    await connectDatabase();
+  });
+
+  beforeEach(async () => {
+    await db.execute(sql`TRUNCATE TABLE ${imagem} RESTART IDENTITY CASCADE`);
+    await db.execute(sql`TRUNCATE TABLE ${exam} RESTART IDENTITY CASCADE`);
+    await db.execute(sql`TRUNCATE TABLE ${usuario} RESTART IDENTITY CASCADE`);
+  });
+
+  async function createExam() {
+    const user = await UsuarioBuilder.anUser().build();
+    return examesRepository.create({
+      id: randomUUID(),
+      idUsuario: user.id,
+      nomeCompleto: 'Fulano de Tal',
+      cpf: cpfUtil.generate(),
+      sexo: Sexo.MASCULINO,
+      dtNascimento: '1990-01-01',
+      dtHora: new Date(),
+      status: ExameStatus.CRIADO,
+    });
+  }
+
+  describe('createMany', () => {
+    it('should persist multiple images and return them', async () => {
+      const exame = await createExam();
+
+      const created = await repository.createMany([
+        {
+          id: randomUUID(),
+          idExame: exame.id,
+          lateralidadeOlho: LateralidadeOlho.OD,
+          caminhoImg: `exams/${exame.id}/od.png`,
+          qualidadeImg: 'Pendente',
+        },
+        {
+          id: randomUUID(),
+          idExame: exame.id,
+          lateralidadeOlho: LateralidadeOlho.OE,
+          caminhoImg: `exams/${exame.id}/oe.png`,
+          qualidadeImg: 'Pendente',
+        },
+      ]);
+
+      expect(created).toHaveLength(2);
+      expect(created[0].caminhoImg).toContain(exame.id);
+
+      const persisted = await repository.findMany({ examId: exame.id });
+      expect(persisted).toHaveLength(2);
+    });
+
+    it('should return empty array when no images are provided', async () => {
+      const result = await repository.createMany([]);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findMany', () => {
+    it('should return empty array when exam has no images', async () => {
+      const exame = await createExam();
+      const result = await repository.findMany({ examId: exame.id });
+      expect(result).toEqual([]);
+    });
+
+    it('should return only images of the given exam', async () => {
+      const exameA = await createExam();
+      const exameB = await createExam();
+
+      await repository.createMany([
+        {
+          id: randomUUID(),
+          idExame: exameA.id,
+          lateralidadeOlho: LateralidadeOlho.OD,
+          caminhoImg: `exams/${exameA.id}/od.png`,
+          qualidadeImg: 'Pendente',
+        },
+        {
+          id: randomUUID(),
+          idExame: exameB.id,
+          lateralidadeOlho: LateralidadeOlho.OE,
+          caminhoImg: `exams/${exameB.id}/oe.png`,
+          qualidadeImg: 'Pendente',
+        },
+      ]);
+
+      const result = await repository.findMany({ examId: exameA.id });
+      expect(result).toHaveLength(1);
+      expect(result[0].idExame).toBe(exameA.id);
+      expect(result[0].lateralidadeOlho).toBe(LateralidadeOlho.OD);
+    });
+  });
+
+  describe('unique (idExame, lateralidadeOlho)', () => {
+    it('should reject duplicate lateralidade for the same exam', async () => {
+      const exame = await createExam();
+
+      await repository.createMany([
+        {
+          id: randomUUID(),
+          idExame: exame.id,
+          lateralidadeOlho: LateralidadeOlho.OD,
+          caminhoImg: `exams/${exame.id}/od.png`,
+          qualidadeImg: 'Pendente',
+        },
+      ]);
+
+      await expect(
+        repository.createMany([
+          {
+            id: randomUUID(),
+            idExame: exame.id,
+            lateralidadeOlho: LateralidadeOlho.OD,
+            caminhoImg: `exams/${exame.id}/od-2.png`,
+            qualidadeImg: 'Pendente',
+          },
+        ]),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/tests/integration/update-user-image-route.test.ts
+++ b/src/tests/integration/update-user-image-route.test.ts
@@ -15,7 +15,12 @@ describe('PATCH /api/usuarios/imagem (integration)', () => {
   let app: FastifyInstance;
   const authSpies = spyOnAuthApi();
   const uploadMock = vi.fn();
-  const stubStorage: StorageService = { upload: uploadMock };
+  const stubStorage: StorageService = {
+    upload: uploadMock,
+    uploadPrivate: vi.fn(),
+    deleteByUrl: vi.fn(),
+    deleteByKey: vi.fn(),
+  };
 
   beforeAll(async () => {
     await connectDatabase();

--- a/src/tests/integration/upload-exam-images-route.test.ts
+++ b/src/tests/integration/upload-exam-images-route.test.ts
@@ -1,0 +1,252 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { sql } from 'drizzle-orm';
+import { asValue } from 'awilix';
+import { randomUUID } from 'node:crypto';
+import { connectDatabase, db } from '@/infra/database/drizzle/connection';
+import { exam, imagem, usuario } from '@/infra/database/drizzle/schema';
+import { UsuarioBuilder } from '@/tests/helpers/builders/usuario-builder';
+import { ExameBuilder } from '@/tests/helpers/builders/exame-builder';
+import { spyOnAuthApi } from '@/tests/helpers/auth-spies';
+import {
+  buildEmptyMultipart,
+  buildMultipartFiles,
+  type MultipartFilePart,
+} from '@/tests/helpers/multipart';
+import { container } from '@/infra/container';
+import type { StorageService } from '@/shared/services';
+import { buildApp } from '@/api/index';
+
+describe('POST /api/exams/:id/images (integration)', () => {
+  let app: FastifyInstance;
+  const authSpies = spyOnAuthApi();
+  const uploadPrivateMock = vi.fn();
+  const deleteByKeyMock = vi.fn();
+  const stubStorage: StorageService = {
+    upload: vi.fn(),
+    uploadPrivate: uploadPrivateMock,
+    deleteByUrl: vi.fn(),
+    deleteByKey: deleteByKeyMock,
+  };
+
+  beforeAll(async () => {
+    await connectDatabase();
+    container.register({ storageService: asValue(stubStorage) });
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    authSpies.restoreAll();
+  });
+
+  beforeEach(async () => {
+    authSpies.resetAll();
+    uploadPrivateMock.mockReset().mockResolvedValue(undefined);
+    deleteByKeyMock.mockReset().mockResolvedValue(undefined);
+    await db.execute(sql`TRUNCATE TABLE ${imagem} RESTART IDENTITY CASCADE`);
+    await db.execute(sql`TRUNCATE TABLE ${exam} RESTART IDENTITY CASCADE`);
+    await db.execute(sql`TRUNCATE TABLE ${usuario} RESTART IDENTITY CASCADE`);
+  });
+
+  function pngFile(field: 'olhoDireito' | 'olhoEsquerdo'): MultipartFilePart {
+    return {
+      fieldName: field,
+      filename: `${field}.png`,
+      contentType: 'image/png',
+      buffer: Buffer.from(`fake-${field}-bytes`),
+    };
+  }
+
+  it('returns 401 when unauthenticated', async () => {
+    authSpies.unauthenticate();
+
+    const { body, headers } = buildMultipartFiles([pngFile('olhoDireito')]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/exams/${randomUUID()}/images`,
+      payload: body,
+      headers,
+    });
+
+    expect(res.statusCode).toBe(401);
+    expect(uploadPrivateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when no files are sent', async () => {
+    const user = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
+    authSpies.authenticateAs(user);
+    const exame = await ExameBuilder.anExame().withIdUsuario(user.id).build();
+
+    const { body, headers } = buildEmptyMultipart();
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/exams/${exame.id}/images`,
+      payload: body,
+      headers,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(uploadPrivateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when MIME type is invalid', async () => {
+    const user = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
+    authSpies.authenticateAs(user);
+    const exame = await ExameBuilder.anExame().withIdUsuario(user.id).build();
+
+    const { body, headers } = buildMultipartFiles([
+      {
+        fieldName: 'olhoDireito',
+        filename: 'foo.gif',
+        contentType: 'image/gif',
+        buffer: Buffer.from('xxx'),
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/exams/${exame.id}/images`,
+      payload: body,
+      headers,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(uploadPrivateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 201 when uploading a single eye', async () => {
+    const user = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
+    authSpies.authenticateAs(user);
+    const exame = await ExameBuilder.anExame().withIdUsuario(user.id).build();
+
+    const { body, headers } = buildMultipartFiles([pngFile('olhoDireito')]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/exams/${exame.id}/images`,
+      payload: body,
+      headers,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const payload = res.json() as { imagens: Array<Record<string, unknown>> };
+    expect(payload.imagens).toHaveLength(1);
+    expect(payload.imagens[0]).toMatchObject({
+      idExame: exame.id,
+      lateralidadeOlho: 'OD',
+      qualidadeImg: 'Pendente',
+    });
+    expect(payload.imagens[0]).not.toHaveProperty('caminhoImg');
+
+    expect(uploadPrivateMock).toHaveBeenCalledTimes(1);
+    expect(uploadPrivateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: expect.stringContaining(`exams/${exame.id}/OD-`),
+        contentType: 'image/png',
+        buffer: expect.any(Buffer),
+      }),
+      'exam-images',
+    );
+
+    const rows = await db.select().from(imagem);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].idExame).toBe(exame.id);
+    expect(rows[0].lateralidadeOlho).toBe('OD');
+    expect(rows[0].qualidadeImg).toBe('Pendente');
+  });
+
+  it('returns 201 when uploading both eyes', async () => {
+    const user = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
+    authSpies.authenticateAs(user);
+    const exame = await ExameBuilder.anExame().withIdUsuario(user.id).build();
+
+    const { body, headers } = buildMultipartFiles([
+      pngFile('olhoDireito'),
+      pngFile('olhoEsquerdo'),
+    ]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/exams/${exame.id}/images`,
+      payload: body,
+      headers,
+    });
+
+    expect(res.statusCode).toBe(201);
+    const payload = res.json() as { imagens: Array<{ lateralidadeOlho: string }> };
+    expect(payload.imagens).toHaveLength(2);
+    const sides = payload.imagens.map((i) => i.lateralidadeOlho).sort();
+    expect(sides).toEqual(['OD', 'OE']);
+    expect(payload.imagens.every((i) => !('caminhoImg' in i))).toBe(true);
+
+    expect(uploadPrivateMock).toHaveBeenCalledTimes(2);
+
+    const rows = await db.select().from(imagem);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('returns 409 on re-upload', async () => {
+    const user = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
+    authSpies.authenticateAs(user);
+    const exame = await ExameBuilder.anExame().withIdUsuario(user.id).build();
+
+    const first = buildMultipartFiles([pngFile('olhoDireito')]);
+    const firstRes = await app.inject({
+      method: 'POST',
+      url: `/api/exams/${exame.id}/images`,
+      payload: first.body,
+      headers: first.headers,
+    });
+    expect(firstRes.statusCode).toBe(201);
+
+    const second = buildMultipartFiles([pngFile('olhoEsquerdo')]);
+    const secondRes = await app.inject({
+      method: 'POST',
+      url: `/api/exams/${exame.id}/images`,
+      payload: second.body,
+      headers: second.headers,
+    });
+
+    expect(secondRes.statusCode).toBe(409);
+  });
+
+  it('returns 404 when medic is not the exam owner', async () => {
+    const owner = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
+    const intruder = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
+    authSpies.authenticateAs(intruder);
+    const exame = await ExameBuilder.anExame().withIdUsuario(owner.id).build();
+
+    const { body, headers } = buildMultipartFiles([pngFile('olhoDireito')]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/exams/${exame.id}/images`,
+      payload: body,
+      headers,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(uploadPrivateMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when exam does not exist', async () => {
+    const user = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
+    authSpies.authenticateAs(user);
+
+    const { body, headers } = buildMultipartFiles([pngFile('olhoDireito')]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/exams/${randomUUID()}/images`,
+      payload: body,
+      headers,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(uploadPrivateMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/modules/exam/create-exam-usecase.test.ts
+++ b/src/tests/unit/modules/exam/create-exam-usecase.test.ts
@@ -20,6 +20,7 @@ class FakeUsuariosRepository implements UsuariosRepository {
 
 class FakeExamesRepository implements ExamesRepository {
   create = vi.fn();
+  findOne = vi.fn();
 }
 
 class FakeCryptographyService implements CryptographyService {

--- a/src/tests/unit/modules/exam/upload-exam-images-usecase.test.ts
+++ b/src/tests/unit/modules/exam/upload-exam-images-usecase.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { faker } from '@faker-js/faker';
+
+import type { ExamesRepository } from '@/modules/exam/exam-repository';
+import type { ImagemRepository } from '@/modules/exam/imagem-repository';
+import { LateralidadeOlho, type Imagem } from '@/modules/exam/imagem';
+import { Buckets, type StorageService } from '@/shared/services';
+import { ConflictError, NotFoundError } from '@/shared/errors';
+import { ExameBuilder } from '@/tests/helpers/builders/exame-builder';
+import {
+  UploadExamImagesUseCase,
+  type UploadExamImageInput,
+} from '@/modules/exam/use-cases/upload-exam-images-usecase';
+
+class FakeExamesRepository implements ExamesRepository {
+  create = vi.fn();
+  findOne = vi.fn();
+}
+
+class FakeImagemRepository implements ImagemRepository {
+  findMany = vi.fn();
+  createMany = vi.fn();
+}
+
+class FakeStorageService implements StorageService {
+  upload = vi.fn();
+  uploadPrivate = vi.fn();
+  deleteByUrl = vi.fn();
+  deleteByKey = vi.fn();
+}
+
+let examRepository: FakeExamesRepository;
+let imagemRepository: FakeImagemRepository;
+let storageService: FakeStorageService;
+let usecase: UploadExamImagesUseCase;
+
+const buildImageInput = (
+  lateralidade: LateralidadeOlho,
+  overrides: Partial<UploadExamImageInput> = {},
+): UploadExamImageInput => ({
+  lateralidade,
+  buffer: Buffer.from('fake-bytes'),
+  contentType: 'image/jpeg',
+  extension: 'jpg',
+  ...overrides,
+});
+
+describe('UploadExamImagesUseCase', () => {
+  beforeEach(() => {
+    examRepository = new FakeExamesRepository();
+    imagemRepository = new FakeImagemRepository();
+    storageService = new FakeStorageService();
+    usecase = new UploadExamImagesUseCase(examRepository, imagemRepository, storageService);
+
+    vi.clearAllMocks();
+  });
+
+  it('should upload a single OD image and persist with qualidadeImg Pendente', async () => {
+    const userId = faker.string.uuid();
+    const exame = ExameBuilder.anExame().withIdUsuario(userId).getData();
+
+    examRepository.findOne.mockResolvedValue(exame);
+    imagemRepository.findMany.mockResolvedValue([]);
+    storageService.uploadPrivate.mockResolvedValue(undefined);
+    imagemRepository.createMany.mockImplementation(async (input: Imagem[]) => input);
+
+    const input = buildImageInput(LateralidadeOlho.OD);
+
+    const result = await usecase.execute({
+      examId: exame.id,
+      userId,
+      imagens: [input],
+    });
+
+    expect(storageService.uploadPrivate).toHaveBeenCalledTimes(1);
+    const [uploadArgs, bucketArg] = storageService.uploadPrivate.mock.calls[0];
+    expect(bucketArg).toBe(Buckets.examImages);
+    expect(uploadArgs.key).toMatch(new RegExp(`^exams/${exame.id}/OD-.+\\.jpg$`));
+    expect(uploadArgs.buffer).toBe(input.buffer);
+    expect(uploadArgs.contentType).toBe('image/jpeg');
+
+    expect(imagemRepository.createMany).toHaveBeenCalledTimes(1);
+    const [persisted] = imagemRepository.createMany.mock.calls[0];
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toEqual(
+      expect.objectContaining({
+        idExame: exame.id,
+        lateralidadeOlho: LateralidadeOlho.OD,
+        caminhoImg: uploadArgs.key,
+        qualidadeImg: 'Pendente',
+      }),
+    );
+    expect(persisted[0].id).toEqual(expect.any(String));
+
+    expect(result.imagens).toEqual([
+      {
+        id: persisted[0].id,
+        idExame: persisted[0].idExame,
+        lateralidadeOlho: persisted[0].lateralidadeOlho,
+        qualidadeImg: persisted[0].qualidadeImg,
+      },
+    ]);
+    expect(result.imagens[0]).not.toHaveProperty('caminhoImg');
+    expect(storageService.deleteByKey).not.toHaveBeenCalled();
+  });
+
+  it('should upload OD and OE images and persist both', async () => {
+    const userId = faker.string.uuid();
+    const exame = ExameBuilder.anExame().withIdUsuario(userId).getData();
+
+    examRepository.findOne.mockResolvedValue(exame);
+    imagemRepository.findMany.mockResolvedValue([]);
+    storageService.uploadPrivate.mockResolvedValue(undefined);
+    imagemRepository.createMany.mockImplementation(async (input: Imagem[]) => input);
+
+    const od = buildImageInput(LateralidadeOlho.OD, {
+      extension: 'png',
+      contentType: 'image/png',
+    });
+    const oe = buildImageInput(LateralidadeOlho.OE);
+
+    const result = await usecase.execute({
+      examId: exame.id,
+      userId,
+      imagens: [od, oe],
+    });
+
+    expect(storageService.uploadPrivate).toHaveBeenCalledTimes(2);
+    const firstKey = storageService.uploadPrivate.mock.calls[0][0].key;
+    const secondKey = storageService.uploadPrivate.mock.calls[1][0].key;
+    expect(firstKey).toMatch(new RegExp(`^exams/${exame.id}/OD-.+\\.png$`));
+    expect(secondKey).toMatch(new RegExp(`^exams/${exame.id}/OE-.+\\.jpg$`));
+
+    expect(imagemRepository.createMany).toHaveBeenCalledTimes(1);
+    const [persisted] = imagemRepository.createMany.mock.calls[0];
+    expect(persisted).toHaveLength(2);
+    expect(persisted[0].lateralidadeOlho).toBe(LateralidadeOlho.OD);
+    expect(persisted[0].caminhoImg).toBe(firstKey);
+    expect(persisted[1].lateralidadeOlho).toBe(LateralidadeOlho.OE);
+    expect(persisted[1].caminhoImg).toBe(secondKey);
+    expect(persisted.every((p: Imagem) => p.qualidadeImg === 'Pendente')).toBe(true);
+
+    expect(result.imagens).toEqual(
+      persisted.map((p: Imagem) => ({
+        id: p.id,
+        idExame: p.idExame,
+        lateralidadeOlho: p.lateralidadeOlho,
+        qualidadeImg: p.qualidadeImg,
+      })),
+    );
+    expect(result.imagens.every((i) => !('caminhoImg' in i))).toBe(true);
+    expect(storageService.deleteByKey).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotFoundError when exam does not exist', async () => {
+    examRepository.findOne.mockResolvedValue(null);
+
+    await expect(
+      usecase.execute({
+        examId: faker.string.uuid(),
+        userId: faker.string.uuid(),
+        imagens: [buildImageInput(LateralidadeOlho.OD)],
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect(storageService.uploadPrivate).not.toHaveBeenCalled();
+    expect(imagemRepository.findMany).not.toHaveBeenCalled();
+    expect(imagemRepository.createMany).not.toHaveBeenCalled();
+  });
+
+  it('should throw NotFoundError when user is not the exam owner', async () => {
+    const exame = ExameBuilder.anExame().withIdUsuario(faker.string.uuid()).getData();
+    examRepository.findOne.mockResolvedValue(exame);
+
+    await expect(
+      usecase.execute({
+        examId: exame.id,
+        userId: faker.string.uuid(),
+        imagens: [buildImageInput(LateralidadeOlho.OD)],
+      }),
+    ).rejects.toBeInstanceOf(NotFoundError);
+
+    expect(storageService.uploadPrivate).not.toHaveBeenCalled();
+    expect(imagemRepository.createMany).not.toHaveBeenCalled();
+  });
+
+  it('should throw ConflictError when exam already has images', async () => {
+    const userId = faker.string.uuid();
+    const exame = ExameBuilder.anExame().withIdUsuario(userId).getData();
+
+    const existingImagem: Imagem = {
+      id: faker.string.uuid(),
+      idExame: exame.id,
+      lateralidadeOlho: LateralidadeOlho.OD,
+      caminhoImg: `exams/${exame.id}/OD-existing.jpg`,
+      qualidadeImg: 'Pendente',
+    };
+
+    examRepository.findOne.mockResolvedValue(exame);
+    imagemRepository.findMany.mockResolvedValue([existingImagem]);
+
+    await expect(
+      usecase.execute({
+        examId: exame.id,
+        userId,
+        imagens: [buildImageInput(LateralidadeOlho.OD)],
+      }),
+    ).rejects.toBeInstanceOf(ConflictError);
+
+    expect(storageService.uploadPrivate).not.toHaveBeenCalled();
+    expect(imagemRepository.createMany).not.toHaveBeenCalled();
+  });
+
+  it('should cleanup uploaded objects and rethrow when a subsequent upload fails', async () => {
+    const userId = faker.string.uuid();
+    const exame = ExameBuilder.anExame().withIdUsuario(userId).getData();
+
+    examRepository.findOne.mockResolvedValue(exame);
+    imagemRepository.findMany.mockResolvedValue([]);
+
+    const uploadError = new Error('storage down');
+    storageService.uploadPrivate
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(uploadError);
+    storageService.deleteByKey.mockResolvedValue(undefined);
+
+    await expect(
+      usecase.execute({
+        examId: exame.id,
+        userId,
+        imagens: [buildImageInput(LateralidadeOlho.OD), buildImageInput(LateralidadeOlho.OE)],
+      }),
+    ).rejects.toBe(uploadError);
+
+    const firstUploadedKey = storageService.uploadPrivate.mock.calls[0][0].key;
+
+    expect(storageService.deleteByKey).toHaveBeenCalledTimes(1);
+    expect(storageService.deleteByKey).toHaveBeenCalledWith(firstUploadedKey, Buckets.examImages);
+    expect(imagemRepository.createMany).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/modules/usuarios/update-user-image-usecase.test.ts
+++ b/src/tests/unit/modules/usuarios/update-user-image-usecase.test.ts
@@ -3,7 +3,7 @@ import type { Usuario } from '@/modules/users/domain';
 import type { UsuariosRepository } from '@/modules/users/repositories/users-repository';
 import { UpdateUserImageUsecase } from '@/modules/users/use-cases/update-user-image-usecase';
 import { NotFoundError } from '@/shared/errors';
-import { Buckets, type StorageService } from '@/shared/services';
+import { BucketName, Buckets, UploadInput, type StorageService } from '@/shared/services';
 import { UsuarioBuilder } from '@/tests/helpers/builders/usuario-builder';
 
 class FakeUsuariosRepository implements UsuariosRepository {
@@ -18,6 +18,8 @@ class FakeUsuariosRepository implements UsuariosRepository {
 class FakeStorageService implements StorageService {
   upload = vi.fn();
   deleteByUrl = vi.fn();
+  deleteByKey = vi.fn();
+  uploadPrivate = vi.fn();
 }
 
 const existingUser: Usuario = UsuarioBuilder.anUser().getData();


### PR DESCRIPTION
## Descrição                                                                                          
                                                                                                        
  Este PR adiciona o fluxo de upload de imagens de retina vinculadas a um exame. O médico autenticado   
  envia até duas imagens (olho direito e olho esquerdo) via `multipart/form-data`, que são gravadas em
  um bucket privado do MinIO e referenciadas em uma nova tabela `imagem`. O upload é transacional: falha
   em qualquer arquivo dispara rollback dos objetos já enviados ao storage antes de propagar o erro. A
  camada de storage ganhou métodos para upload privado e remoção por chave.

  ## Issue

  Closes #18 
   
  <!---#TAGdaIssue -->                                                                                  
                                                            
  ## Principais Implementações                                                                          
                                                            
* **Tabela `imagem`**: FK com `ON DELETE CASCADE`, índice único por exame + olho e índice por exame.
* **Domínio `Imagem`**: entidade + enums (`OD`/`OE`) e repositório com `findMany`/`createMany`.
* **Repositório (Drizzle)**: faz o mapeamento entre banco e domínio.
* **Use case**: valida exame, impede duplicidade, faz upload e persiste; rollback em erro.
* **Storage**: upload privado e deleção por chave em bucket de imagens.
* **ExamesRepository.findOne**: usado para validar existência/propriedade.
* **Erro de conflito**: lançado quando exame já tem imagens.
* **Rota `POST /exams/:id/images`**: autenticada, valida MIME e campos (`OD`/`OE`).
* **Testes**: unitários, integração de repositório e rota cobrindo cenários principais.                                   
                                                            
  ## Tipos de Mudanças

  - [ ] Bug fix (alteração que corrige uma issue e não altera funcionalidades já existentes);           
  - [x] Nova feature (alteração que adiciona uma funcionalidade e não altera funcionalidades já
  existentes);                                                                                          
  - [ ] Alteração disruptiva (Breaking change) (Correção ou funcionalidade que causa alteração nas
  funcionalidades existentes);                                                                          
  - [ ] Documentação                                        
                                                                                                        
  ## Como testar
                                                                                                        
  ### Pré-requisitos                                        

  - Subir Postgres + MinIO: `docker compose -f docker-compose.dev.yml up -d --build`.
  - Criar um usuário com perfil `MEDICO` e um exame via `POST /api/exams` (anote o `id` retornado). 
  - Fazer login via `POST /api/auth/sign-in/email` e copiar o cookie de sessão.
                                                            
  ### `curl`                                                                                            
                                                            
  ```bash
  curl --location 'http://localhost:3000/api/exams/:examId/images' \
  --header 'Cookie: better-auth.session_token=TOKEN' \                                                  
  --form 'olhoDireito=@"./od.png"' \
  --form 'olhoEsquerdo=@"./oe.png"'                                                                     
  ```                                                       
                                                                                                        
  ### Resultado esperado                                    

  - Status `201` com payload `{ "imagens": [{ "id", "idExame", "lateralidadeOlho", "qualidadeImg":      
  "Pendente" }, ...] }`.
  - No bucket do MinIO, dois objetos sob a chave `exams/EXAM_ID/OD-<uuid>.jpg` e           
  `exams/EXAM_ID/OE-<uuid>.png`.                                                                        
  - Na tabela `imagem`, dois registros com `qualidade_img = 'Pendente'` referenciando o exame.
  - Repetir a chamada para o mesmo exame retorna `409 Conflict`.                                        
  - Chamar com `examId` inexistente ou de outro médico retorna `404 Not Found`.                         
  - Enviar arquivo com MIME diferente de `image/jpeg`/`image/png` retorna `400` com `ValidationError`.
                                                                                                        
  ## Evidências                                             
                                                                                                        
  <!--- Adicionar prints da resposta do endpoint, dos objetos no MinIO, do registro no banco e da       
  execução dos testes -->
                                                                                                        
  > ### Cenário de sucesso (OD + OE)
  
<img width="984" height="725" alt="image" src="https://github.com/user-attachments/assets/897e7d54-923c-4e4d-bdcc-e4b47a96c64f" />             

  </br>

  > ### Objetos persistidos no bucket do MinIO
  
  
<img width="1151" height="637" alt="image" src="https://github.com/user-attachments/assets/13741fdd-82a3-44d6-b23f-37b39c1f8fee" />                                               
   
  </br>                                                                                                 
                                                            
  > ### Erro de conflito (exame já possui imagens)
  
<img width="987" height="507" alt="image" src="https://github.com/user-attachments/assets/f66cb907-38c5-4aff-a68a-5777a0eb034b" />

  </br>

  > ### Erro de validação (MIME inválido)
  
<img width="990" height="644" alt="image" src="https://github.com/user-attachments/assets/0e811b3b-b6fe-4a68-8384-d0247c770614" />
   
  </br>