### PR TITLE
fix: Erro ao editar os dados do Admin Cadastrado Automaticamente

### DIFF
--- a/src/modules/users/use-cases/ensure-admin-exists.ts
+++ b/src/modules/users/use-cases/ensure-admin-exists.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { eq, or } from 'drizzle-orm';
 
 import logger from '@/infra/logger';
 import { db } from '@/infra/database/drizzle/connection';
@@ -29,10 +29,18 @@ export async function ensureAdminUserExists(): Promise<void> {
       .select({
         idUsuario: usuario.id,
         email: usuario.email,
+        cpf: usuario.cpf,
+        crm: usuario.crm,
         tipoPerfil: usuario.tipoPerfil,
       })
       .from(usuario)
-      .where(eq(usuario.email, env.ADMIN_EMAIL))
+      .where(
+        or(
+          eq(usuario.email, env.ADMIN_EMAIL),
+          eq(usuario.cpf, env.ADMIN_CPF),
+          eq(usuario.crm, env.ADMIN_CRM),
+        ),
+      )
       .limit(1);
 
     if (!existingAdmin[0]) {
@@ -58,9 +66,15 @@ export async function ensureAdminUserExists(): Promise<void> {
     } else {
       logger.info('Administrador já existe.', {
         email: existingAdmin[0].email,
+        cpf: existingAdmin[0].cpf,
+        crm: existingAdmin[0].crm,
         tipoPerfil: existingAdmin[0].tipoPerfil,
       });
     }
+
+    const whereClause = existingAdmin[0]
+      ? eq(usuario.id, existingAdmin[0].idUsuario)
+      : eq(usuario.email, env.ADMIN_EMAIL);
 
     await db
       .update(usuario)
@@ -68,7 +82,7 @@ export async function ensureAdminUserExists(): Promise<void> {
         tipoPerfil: 'ADMIN',
         status: 'ATIVO',
       })
-      .where(eq(usuario.email, env.ADMIN_EMAIL));
+      .where(whereClause);
 
     logger.info('Perfil ADMIN garantido com sucesso.', {
       email: env.ADMIN_EMAIL,

--- a/src/tests/unit/modules/usuarios/ensure-admin-existes.test.ts
+++ b/src/tests/unit/modules/usuarios/ensure-admin-existes.test.ts
@@ -32,6 +32,8 @@ vi.mock('@/infra/database/drizzle/schema', () => ({
   usuario: {
     id: 'id',
     email: 'email',
+    cpf: 'cpf',
+    crm: 'crm',
     tipoPerfil: 'tipoPerfil',
   },
 }));
@@ -91,7 +93,29 @@ describe('ensureAdminUserExists', () => {
   it('should not create admin if already exists', async () => {
     limitMock.mockResolvedValue([
       {
+        idUsuario: 'admin-id',
         email: 'admin@test.com',
+        cpf: '00000000000',
+        crm: '0001',
+        tipoPerfil: 'ADMIN',
+      },
+    ]);
+
+    const mod = await import('@/modules/users/use-cases/ensure-admin-exists.js');
+
+    await mod.ensureAdminUserExists();
+
+    expect(signUpEmailMock).not.toHaveBeenCalled();
+    expect(updateWhereMock).toHaveBeenCalled();
+  });
+
+  it('should not recreate admin when email changed but cpf/crm already exist', async () => {
+    limitMock.mockResolvedValue([
+      {
+        idUsuario: 'admin-id',
+        email: 'admin-alterado@test.com',
+        cpf: '00000000000',
+        crm: '0001',
         tipoPerfil: 'ADMIN',
       },
     ]);


### PR DESCRIPTION
## Descrição

Correção do bug de atualizacao do e-mail do admin.

## Issue
#13 Erro ao editar os dados do Admin Cadastrado Automaticamente

## Principais Implementações
Foi alterado a lógica da busca do perfil de admin, que antes era apenas por e-mail, e agora é por e-mail ou cpf ou crm e posteriormente feita a atualização a partir do id do registro encontrado na busca, em caso não, o usuário admin é criado conforme o fluxo anteriormente já criado.

## Tipos de Mudanças
 - [x] Bug fix (alteração que corrige uma issue e não altera funcionalidades já existentes);
 - [ ] Nova feature (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes);
 - [ ] Alteração disruptiva (Breaking change) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes);
 - [ ] Documentação
