### PR TITLE
Fix erro generico criacao de usuario existente

### DIFF
--- a/src/api/routes/users/create-user-by-admin.ts
+++ b/src/api/routes/users/create-user-by-admin.ts
@@ -1,6 +1,7 @@
 import { DrizzleUsuariosRepository } from '@/infra/database/drizzle/repositories';
 import { CreateUserByAdmin } from '@/modules/users/use-cases';
 import { better_auth_errors } from '@/shared/errors/better-auth-errors';
+import { ConflictError } from '@/shared/errors/conflict-error';
 import { isValidCpf } from '@/shared/validators/is-valid-cpf';
 import type { FastifyRequest, FastifyReply } from 'fastify';
 import z from 'zod';
@@ -58,6 +59,14 @@ export async function createUserByAdmin(request: FastifyRequest, reply: FastifyR
       message: 'Usuário criado com sucesso.',
     });
   } catch (error: unknown) {
+    if (error instanceof ConflictError) {
+      return reply.status(409).send({
+        statusCode: 409,
+        error: 'Conflict',
+        message: error.message,
+      });
+    }
+
     const code = getErrorCode(error);
 
     return reply.status(400).send({

--- a/src/tests/unit/modules/usuarios/routes/create-user-by-admin-route.test.ts
+++ b/src/tests/unit/modules/usuarios/routes/create-user-by-admin-route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createUserByAdmin } from '@/api/routes/users/create-user-by-admin';
 import { CreateUserByAdmin } from '@/modules/users/use-cases';
 import { better_auth_errors } from '@/shared/errors/better-auth-errors';
+import { ConflictError } from '@/shared/errors/conflict-error';
 
 // 1. Mock das dependências externas
 vi.mock('@/modules/users/use-cases');
@@ -125,6 +126,69 @@ describe('createUserByAdmin Controller', () => {
           message: 'Erro ao criar usuário.',
         }),
       );
+    });
+  });
+
+  describe('Tratamento de Erro 409 - Conflict', () => {
+    it('deve retornar 409 quando o Use Case lança ConflictError por email duplicado', async () => {
+      const conflictError = new ConflictError('Email já cadastrado');
+
+      vi.spyOn(CreateUserByAdmin.prototype, 'execute').mockRejectedValue(conflictError);
+
+      await createUserByAdmin(mockRequest, mockReply);
+
+      expect(mockReply.status).toHaveBeenCalledWith(409);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        statusCode: 409,
+        error: 'Conflict',
+        message: 'Email já cadastrado',
+      });
+    });
+
+    it('deve retornar 409 quando o Use Case lança ConflictError por CPF duplicado', async () => {
+      const conflictError = new ConflictError('CPF já cadastrado');
+
+      vi.spyOn(CreateUserByAdmin.prototype, 'execute').mockRejectedValue(conflictError);
+
+      await createUserByAdmin(mockRequest, mockReply);
+
+      expect(mockReply.status).toHaveBeenCalledWith(409);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        statusCode: 409,
+        error: 'Conflict',
+        message: 'CPF já cadastrado',
+      });
+    });
+
+    it('deve retornar 409 quando o Use Case lança ConflictError por CRM duplicado', async () => {
+      const conflictError = new ConflictError('CRM já cadastrado');
+
+      vi.spyOn(CreateUserByAdmin.prototype, 'execute').mockRejectedValue(conflictError);
+
+      await createUserByAdmin(mockRequest, mockReply);
+
+      expect(mockReply.status).toHaveBeenCalledWith(409);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        statusCode: 409,
+        error: 'Conflict',
+        message: 'CRM já cadastrado',
+      });
+    });
+
+    it('deve retornar 409 com mensagem de erro customizada de ConflictError', async () => {
+      const customMessage = 'Recurso duplicado: Este usuário já existe no sistema';
+      const conflictError = new ConflictError(customMessage);
+
+      vi.spyOn(CreateUserByAdmin.prototype, 'execute').mockRejectedValue(conflictError);
+
+      await createUserByAdmin(mockRequest, mockReply);
+
+      expect(mockReply.status).toHaveBeenCalledWith(409);
+      expect(mockReply.send).toHaveBeenCalledWith({
+        statusCode: 409,
+        error: 'Conflict',
+        message: customMessage,
+      });
     });
   });
 });


### PR DESCRIPTION
## Descrição

Adicionando erro mais especialista sobre falha na criação de usuário com os mesmos dados.

## Issue
#21 - Erro genérico ao tentar criar um usuário com os mesmos dados.

## Principais Implementações
- Mapeia ConflictError para 409 no endpoint POST /api/usuarios
- Mantém fallback 400 para outros erros do better-auth


## Tipos de Mudanças
 - [x] Bug fix (alteração que corrige uma issue e não altera funcionalidades já existentes);
 - [ ] Nova feature (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes);
 - [ ] Alteração disruptiva (Breaking change) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes);
 - [ ] Documentação
