### PR TITLE
feat: adiciona funcionalidade de geração de PDF de exame

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,6 +61,15 @@ services:
     command: redis-server --requirepass redispw
     restart: always
 
+  gotenberg:
+    image: gotenberg/gotenberg:8
+    container_name: retina-scan-gotenberg
+    ports:
+      - "3001:3000"
+    networks:
+      - retina-scan-network
+    restart: always
+
   api:
     build:
       context: .

--- a/src/api/docs/report/generate-pdf-report.schema.ts
+++ b/src/api/docs/report/generate-pdf-report.schema.ts
@@ -1,0 +1,32 @@
+import type { FastifySchema } from 'fastify';
+import {
+  unauthorizedResponse,
+  forbiddenResponse,
+  notFoundResponse,
+  internalErrorResponse,
+} from '../shared/error-responses';
+
+export const generatePdfReportSchema: FastifySchema = {
+  summary: 'Gera e baixa o laudo do exame em PDF',
+  description:
+    'Agrega os dados do exame, preenche o template HTML dinâmico e consome o serviço do Gotenberg para retornar um documento PDF.',
+  tags: ['Report'],
+  params: {
+    type: 'object',
+    properties: {
+      examId: { type: 'string', format: 'uuid' },
+    },
+    required: ['examId'],
+  },
+  response: {
+    200: {
+      description: 'Arquivo PDF gerado com sucesso',
+      type: 'string',
+      format: 'binary',
+    },
+    401: unauthorizedResponse,
+    403: forbiddenResponse,
+    404: notFoundResponse,
+    500: internalErrorResponse,
+  },
+};

--- a/src/api/routes/report.ts
+++ b/src/api/routes/report.ts
@@ -11,6 +11,8 @@ import {
 } from '../docs/report/report.schema';
 import { getExamEditingLocks } from './report/get-exams-report-locks';
 import { heartbeatReportLock } from './report/heart-beart-report-lock';
+import { generatePdfReport } from './report/generate-pdf-report';
+import { generatePdfReportSchema } from '../docs/report/generate-pdf-report.schema';
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function reportRoutes(app: FastifyInstance): Promise<void> {
@@ -98,5 +100,16 @@ export async function reportRoutes(app: FastifyInstance): Promise<void> {
       },
     },
     handler: updateSpecialistReport,
+  });
+
+  app.route({
+    method: 'GET',
+    url: '/report/:examId/pdf',
+    schema: generatePdfReportSchema,
+    preHandler: [
+      authenticationMiddleware,
+      authorizationMiddleware([tiposPerfil.MEDICO, tiposPerfil.ADMIN, tiposPerfil.ESPECIALISTA]),
+    ],
+    handler: generatePdfReport,
   });
 }

--- a/src/api/routes/report/generate-pdf-report.ts
+++ b/src/api/routes/report/generate-pdf-report.ts
@@ -1,0 +1,35 @@
+import type { FastifyReply, FastifyRequest } from 'fastify';
+import { container } from '@/infra/container';
+import type { GeneratePdfReportUseCase } from '@/modules/exam/use-cases/generate-pdf-report-usecase';
+
+export async function generatePdfReport(
+  request: FastifyRequest<{ Params: { examId: string } }>,
+  reply: FastifyReply,
+) {
+  const { examId } = request.params;
+  const user = request.user;
+
+  if (!user) {
+    return reply.status(401).send({ message: 'Usuário não autenticado.' });
+  }
+
+  try {
+    const generatePdfReportUseCase: GeneratePdfReportUseCase = container.resolve(
+      'generatePdfReportUseCase',
+    );
+
+    const pdfBuffer = await generatePdfReportUseCase.execute({
+      examId,
+      requester: { id: user.id, tipoPerfil: user.tipoPerfil },
+    });
+
+    return reply
+      .status(200)
+      .header('Content-Type', 'application/pdf')
+      .header('Content-Disposition', `attachment; filename="relatorio-exame-${examId}.pdf"`)
+      .send(pdfBuffer);
+  } catch (error) {
+    request.log.error(error, `Erro ao gerar PDF para o exame ${examId}`);
+    return reply.status(500).send({ message: 'Erro interno ao gerar o documento PDF.' });
+  }
+}

--- a/src/infra/container/index.ts
+++ b/src/infra/container/index.ts
@@ -62,8 +62,7 @@ import type { DicomService } from '@/shared/services/dicom-service';
 import type { MaskingService } from '@/shared/services/masking-service';
 import type { MessageBroker } from '@/shared/services/message-broker';
 import { AuthEmailMessageService, type IMessageService } from '@/shared/services/message-service';
-import { GotenbergPdfService } from '@/shared/services/pdf-service';
-import type { PdfService } from '@/shared/services/pdf-service';
+import { GotenbergPdfService, type PdfService } from '@/shared/services/pdf-service';
 
 import type { AuditLogsRepository } from '@/modules/audit-log/audit-log-repository';
 import { ListLogsWithFiltersUseCase } from '@/modules/audit-log/use-case/list-logs-with-filters';

--- a/src/infra/container/index.ts
+++ b/src/infra/container/index.ts
@@ -46,6 +46,7 @@ import { RegisterExamAiResultUseCase } from '@/modules/exam/use-cases/register-e
 import { RegisterExamAiErrorUseCase } from '@/modules/exam/use-cases/register-exam-ai-error-usecase';
 import { CreateSpecialistReportUseCase } from '@/modules/exam/use-cases/create-specialist-report-usecase';
 import { UpdateSpecialistReportUseCase } from '@/modules/exam/use-cases/update-specialist-report-usecase';
+import { GeneratePdfReportUseCase } from '@/modules/exam/use-cases/generate-pdf-report-usecase';
 
 import type { ExamesRepository } from '@/modules/exam/exam-repository';
 import type { ImagemRepository } from '@/modules/exam/imagem-repository';
@@ -61,6 +62,8 @@ import type { DicomService } from '@/shared/services/dicom-service';
 import type { MaskingService } from '@/shared/services/masking-service';
 import type { MessageBroker } from '@/shared/services/message-broker';
 import { AuthEmailMessageService, type IMessageService } from '@/shared/services/message-service';
+import { GotenbergPdfService } from '@/shared/services/pdf-service';
+import type { PdfService } from '@/shared/services/pdf-service';
 
 import type { AuditLogsRepository } from '@/modules/audit-log/audit-log-repository';
 import { ListLogsWithFiltersUseCase } from '@/modules/audit-log/use-case/list-logs-with-filters';
@@ -126,6 +129,9 @@ export interface AppContainer {
   listLogsWithFiltersUseCase: ListLogsWithFiltersUseCase;
   authMessageService: IMessageService;
   reportEditingPresenceService: RedisReportEditingPresenceService;
+
+  pdfService: PdfService;
+  generatePdfReportUseCase: GeneratePdfReportUseCase;
 }
 
 export const container: AwilixContainer<AppContainer> = createContainer<AppContainer>({
@@ -156,6 +162,7 @@ container.register({
   cryptographyService: asClass(NodeCryptoCryptographyService).singleton(),
   maskingService: asClass(DefaultMaskingService).singleton(),
   messageBroker: asClass(BullMQMessageBroker).singleton(),
+  pdfService: asClass(GotenbergPdfService).singleton(),
 
   reportEditingPresenceService: asFunction(
     ({ redis }: AppContainer) => new RedisReportEditingPresenceService(redis),
@@ -343,6 +350,11 @@ container.register({
         specialistReportRepository,
         notificationService,
       ),
+  ).scoped(),
+
+  generatePdfReportUseCase: asFunction(
+    ({ getExamDetailsUseCase, pdfService }: AppContainer) =>
+      new GeneratePdfReportUseCase(getExamDetailsUseCase, pdfService),
   ).scoped(),
 });
 

--- a/src/modules/exam/use-cases/generate-pdf-report-usecase.ts
+++ b/src/modules/exam/use-cases/generate-pdf-report-usecase.ts
@@ -23,18 +23,18 @@ export class GeneratePdfReportUseCase {
 
   private formatCpf(cpf?: string): string {
     if (!cpf) return 'Não informado';
-    
+
     const cleaned = String(cpf).replace(/\D/g, '');
-    if (cleaned.length !== 11) return cpf; 
-    
+    if (cleaned.length !== 11) return cpf;
+
     return cleaned.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
   }
 
   private formatDate(date?: string | Date): string {
     if (!date) return 'Não informado';
-    
+
     const d = new Date(date);
-    
+
     if (isNaN(d.getTime())) return String(date);
     return d.toLocaleDateString('pt-BR', { timeZone: 'UTC' });
   }

--- a/src/modules/exam/use-cases/generate-pdf-report-usecase.ts
+++ b/src/modules/exam/use-cases/generate-pdf-report-usecase.ts
@@ -25,11 +25,10 @@ export class GeneratePdfReportUseCase {
     const pacienteNome = data.nomeCompleto || 'Não informado';
     const pacienteCpf = data.cpf || 'Não informado';
     const pacienteNasc = data.dtNascimento || 'Não informado';
-    const dataHora = data.dtHora
-      ? new Date(data.dtHora).toLocaleString('pt-BR')
-      : 'Data não registrada';
+    const dataHora = new Date(data.dtHora).toLocaleString('pt-BR');
     const laudoTexto = data.laudoEspecialista?.texto || 'Laudo estruturado ainda não preenchido.';
     const prontuarioTexto = data.descricao || 'Nenhuma nota médica registrada.';
+    const medicoNome = data.medico.nomeCompleto;
 
     const imagensHtml =
       data.imagens.length > 0
@@ -99,7 +98,7 @@ export class GeneratePdfReportUseCase {
         </table>
 
         <h2>Imagens do Exame</h2>
-        ${imagensHtml || '<p>Nenhuma imagem disponível.</p>'}
+        ${imagensHtml}
 
         <h2>Detalhes do Exame</h2>
         <table>
@@ -107,7 +106,7 @@ export class GeneratePdfReportUseCase {
           <tr><td class="label">Data/Hora:</td><td>${dataHora}</td></tr>
           <tr><td class="label">Olho:</td><td>${data.olho || 'Não especificado'}</td></tr>
           <tr><td class="label">Status:</td><td>${data.status}</td></tr>
-          <tr><td class="label">Médico:</td><td>${data.medico.nomeCompleto}</td></tr>
+          <tr><td class="label">Médico:</td><td>${medicoNome}</td></tr>
         </table>
 
         <h2>Comorbidades</h2>

--- a/src/modules/exam/use-cases/generate-pdf-report-usecase.ts
+++ b/src/modules/exam/use-cases/generate-pdf-report-usecase.ts
@@ -1,0 +1,125 @@
+import type {
+  GetExamDetailsUseCase,
+  GetExamDetailsUseCaseInput,
+  GetExamDetailsUseCaseOutput,
+} from './get-exam-details-usecase';
+import type { PdfService } from '@/shared/services/pdf-service';
+
+export class GeneratePdfReportUseCase {
+  constructor(
+    private readonly getExamDetailsUseCase: GetExamDetailsUseCase,
+    private readonly pdfService: PdfService,
+  ) {}
+
+  async execute(input: GetExamDetailsUseCaseInput): Promise<Buffer> {
+    const examDetails = await this.getExamDetailsUseCase.execute(input);
+
+    const htmlString = this.buildHtmlReport(examDetails);
+
+    const pdfBuffer = await this.pdfService.generateFromHtml(htmlString);
+
+    return pdfBuffer;
+  }
+
+  private buildHtmlReport(data: GetExamDetailsUseCaseOutput): string {
+    const pacienteNome = data.nomeCompleto || 'Não informado';
+    const pacienteCpf = data.cpf || 'Não informado';
+    const pacienteNasc = data.dtNascimento || 'Não informado';
+    const dataHora = data.dtHora
+      ? new Date(data.dtHora).toLocaleString('pt-BR')
+      : 'Data não registrada';
+    const laudoTexto = data.laudoEspecialista?.texto || 'Laudo estruturado ainda não preenchido.';
+    const prontuarioTexto = data.descricao || 'Nenhuma nota médica registrada.';
+
+    const imagensHtml =
+      data.imagens.length > 0
+        ? `
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-bottom: 20px;">
+          ${data.imagens
+            .map(
+              (img) => `
+            <div style="page-break-inside: avoid;">
+              <p style="font-weight: bold; margin-bottom: 5px; font-size: 12px;">Olho: ${img.lateralidadeOlho === 'OD' ? 'Direito' : 'Esquerdo'}</p>
+              <img src="${img.url}" style="width: 100%; height: auto; border: 1px solid #ccc; border-radius: 4px;" />
+              ${
+                img.resultadoIa
+                  ? `
+                <p style="font-size: 10px; color: #555; margin-top: 5px;">IA: ${img.resultadoIa.predictedLabel} (${(img.resultadoIa.confidence * 100).toFixed(1)}% de conf.)</p>`
+                  : 'Resultado Indisponível'
+              }
+            </div>
+          `,
+            )
+            .join('')}
+        </div>
+      `
+        : '<p>Nenhuma imagem disponível.</p>';
+
+    const comorbidadesHtml = data.comorbidades
+      ? `<ul>${
+          [
+            data.comorbidades.diabetes
+              ? `<li>Diabetes${data.comorbidades.diabetesControlado ? ' (Controlado)' : ''}</li>`
+              : '',
+            data.comorbidades.hipertensao
+              ? `<li>Hipertensão${data.comorbidades.hipertensaoControlada ? ' (Controlada)' : ''}</li>`
+              : '',
+            data.comorbidades.altaMiopia ? '<li>Alta Miopia</li>' : '',
+            data.comorbidades.catarata ? '<li>Catarata</li>' : '',
+            data.comorbidades.glaucoma ? '<li>Glaucoma</li>' : '',
+            data.comorbidades.usoHidroxicloroquina ? '<li>Uso de Hidroxicloroquina</li>' : '',
+          ]
+            .filter(Boolean)
+            .join('') || '<li>Nenhuma comorbidade reportada.</li>'
+        }</ul>`
+      : '<p>Informações não disponíveis.</p>';
+
+    return `
+      <!DOCTYPE html>
+      <html lang="pt-BR">
+      <head>
+        <meta charset="UTF-8">
+        <style>
+          body { font-family: 'Helvetica', 'Arial', sans-serif; font-size: 13px; color: #000; line-height: 1.4; margin: 40px; }
+          h1 { font-size: 22px; margin-bottom: 20px; border-bottom: 2px solid #000; padding-bottom: 5px; }
+          h2 { font-size: 14px; margin-top: 25px; margin-bottom: 10px; color: #000; border-bottom: 1px solid #ccc; text-transform: uppercase; }
+          table { width: 100%; margin-bottom: 20px; border-spacing: 0; }
+          td { padding: 4px 8px; vertical-align: top; }
+          .label { font-weight: bold; width: 150px; }
+        </style>
+      </head>
+      <body>
+        <h1>Laudo de Exame - RetinaScan</h1>
+        
+        <h2>Dados do Paciente</h2>
+        <table>
+          <tr><td class="label">Nome:</td><td>${pacienteNome}</td></tr>
+          <tr><td class="label">CPF:</td><td>${pacienteCpf}</td></tr>
+          <tr><td class="label">Data de Nasc.:</td><td>${pacienteNasc}</td></tr>
+        </table>
+
+        <h2>Imagens do Exame</h2>
+        ${imagensHtml || '<p>Nenhuma imagem disponível.</p>'}
+
+        <h2>Detalhes do Exame</h2>
+        <table>
+          <tr><td class="label">ID Exame:</td><td>${data.id}</td></tr>
+          <tr><td class="label">Data/Hora:</td><td>${dataHora}</td></tr>
+          <tr><td class="label">Olho:</td><td>${data.olho || 'Não especificado'}</td></tr>
+          <tr><td class="label">Status:</td><td>${data.status}</td></tr>
+          <tr><td class="label">Médico:</td><td>${data.medico.nomeCompleto}</td></tr>
+        </table>
+
+        <h2>Comorbidades</h2>
+        ${comorbidadesHtml}
+
+        <h2>Prontuário Médico</h2>
+        <p>${prontuarioTexto}</p>
+
+        <h2>Laudo do Especialista</h2>
+        <p>${laudoTexto}</p>
+      </body>
+      </html>
+    `;
+  }
+}

--- a/src/modules/exam/use-cases/generate-pdf-report-usecase.ts
+++ b/src/modules/exam/use-cases/generate-pdf-report-usecase.ts
@@ -21,10 +21,28 @@ export class GeneratePdfReportUseCase {
     return pdfBuffer;
   }
 
+  private formatCpf(cpf?: string): string {
+    if (!cpf) return 'Não informado';
+    
+    const cleaned = String(cpf).replace(/\D/g, '');
+    if (cleaned.length !== 11) return cpf; 
+    
+    return cleaned.replace(/(\d{3})(\d{3})(\d{3})(\d{2})/, '$1.$2.$3-$4');
+  }
+
+  private formatDate(date?: string | Date): string {
+    if (!date) return 'Não informado';
+    
+    const d = new Date(date);
+    
+    if (isNaN(d.getTime())) return String(date);
+    return d.toLocaleDateString('pt-BR', { timeZone: 'UTC' });
+  }
+
   private buildHtmlReport(data: GetExamDetailsUseCaseOutput): string {
     const pacienteNome = data.nomeCompleto || 'Não informado';
-    const pacienteCpf = data.cpf || 'Não informado';
-    const pacienteNasc = data.dtNascimento || 'Não informado';
+    const pacienteCpf = this.formatCpf(data.cpf);
+    const pacienteNasc = this.formatDate(data.dtNascimento);
     const dataHora = new Date(data.dtHora).toLocaleString('pt-BR');
     const laudoTexto = data.laudoEspecialista?.texto || 'Laudo estruturado ainda não preenchido.';
     const prontuarioTexto = data.descricao || 'Nenhuma nota médica registrada.';

--- a/src/shared/services/pdf-service.ts
+++ b/src/shared/services/pdf-service.ts
@@ -1,0 +1,39 @@
+import FormData from 'form-data';
+import axios from 'axios';
+import { env } from '@/env';
+
+export interface PdfService {
+  generateFromHtml(htmlString: string): Promise<Buffer>;
+}
+
+export class GotenbergPdfService implements PdfService {
+  private readonly gotenbergUrl = process.env.GOTENBERG_URL ?? 'http://gotenberg:3000';
+
+  async generateFromHtml(htmlString: string): Promise<Buffer> {
+    const formData = new FormData();
+
+    formData.append('files', Buffer.from(htmlString, 'utf-8'), {
+      filename: 'index.html',
+      contentType: 'text/html',
+    });
+
+    try {
+      const response = await axios.post(
+        `${this.gotenbergUrl}/forms/chromium/convert/html`,
+        formData,
+        {
+          headers: {
+            ...formData.getHeaders(),
+          },
+          responseType: 'arraybuffer',
+          timeout: 10000,
+        },
+      );
+
+      return Buffer.from(response.data);
+    } catch (error) {
+      console.error('[GotenbergPdfService] Falha ao converter HTML para PDF:', error);
+      throw new Error('Falha interna ao gerar o arquivo PDF do laudo.');
+    }
+  }
+}

--- a/src/shared/services/pdf-service.ts
+++ b/src/shared/services/pdf-service.ts
@@ -1,6 +1,5 @@
 import FormData from 'form-data';
 import axios from 'axios';
-import { env } from '@/env';
 
 export interface PdfService {
   generateFromHtml(htmlString: string): Promise<Buffer>;
@@ -33,7 +32,7 @@ export class GotenbergPdfService implements PdfService {
       return Buffer.from(response.data);
     } catch (error) {
       console.error('[GotenbergPdfService] Falha ao converter HTML para PDF:', error);
-      throw new Error('Falha interna ao gerar o arquivo PDF do laudo.');
+      throw new Error('Falha interna ao gerar o arquivo PDF do laudo.', { cause: error });
     }
   }
 }

--- a/src/tests/integration/generate-pdf-report-route.test.ts
+++ b/src/tests/integration/generate-pdf-report-route.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { FastifyInstance } from 'fastify';
 import { sql } from 'drizzle-orm';
+import { asValue } from 'awilix';
 import { db } from '@/infra/database/drizzle/connection';
 import { exam, imagem, usuario } from '@/infra/database/drizzle/schema';
 import { UsuarioBuilder } from '@/tests/helpers/builders/usuario-builder';
@@ -45,9 +46,9 @@ describe('GET /api/report/:examId/pdf (integration)', () => {
     const exame = await ExameBuilder.anExame().withIdUsuario(medico.id).build();
 
     container.register({
-      pdfService: {
+      pdfService: asValue({
         generateFromHtml: vi.fn().mockResolvedValue(Buffer.from('fake-pdf-content'))
-      } as any
+      })
     });
 
     const res = await app.inject({ 

--- a/src/tests/integration/generate-pdf-report-route.test.ts
+++ b/src/tests/integration/generate-pdf-report-route.test.ts
@@ -1,0 +1,74 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { sql } from 'drizzle-orm';
+import { db } from '@/infra/database/drizzle/connection';
+import { exam, imagem, usuario } from '@/infra/database/drizzle/schema';
+import { UsuarioBuilder } from '@/tests/helpers/builders/usuario-builder';
+import { ExameBuilder } from '@/tests/helpers/builders/exame-builder';
+import { spyOnAuthApi } from '@/tests/helpers/auth-spies';
+import { buildApp } from '@/api/index';
+import { container } from '@/infra/container';
+
+describe('GET /api/report/:examId/pdf (integration)', () => {
+  let app: FastifyInstance;
+  const authSpies = spyOnAuthApi();
+
+  beforeAll(async () => {
+    app = await buildApp();
+    await app.ready();
+  });
+
+  afterAll(async () => {
+    await app.close();
+    authSpies.restoreAll();
+  });
+
+  beforeEach(async () => {
+    authSpies.resetAll();
+    await db.execute(sql`TRUNCATE TABLE ${imagem} RESTART IDENTITY CASCADE`);
+    await db.execute(sql`TRUNCATE TABLE ${exam} RESTART IDENTITY CASCADE`);
+    await db.execute(sql`TRUNCATE TABLE ${usuario} RESTART IDENTITY CASCADE`);
+  });
+
+  it('deve retornar 401 se o usuário não estiver autenticado', async () => {
+    authSpies.unauthenticate();
+    const res = await app.inject({ 
+      method: 'GET', 
+      url: '/api/report/c54a1d75-f346-4627-860f-13d492511058/pdf' 
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('deve gerar PDF com sucesso quando usuário é ESPECIALISTA', async () => {
+    const medico = await UsuarioBuilder.anUser().withTipoPerfil('ESPECIALISTA').build();
+    authSpies.authenticateAs(medico);
+    const exame = await ExameBuilder.anExame().withIdUsuario(medico.id).build();
+
+    container.register({
+      pdfService: {
+        generateFromHtml: vi.fn().mockResolvedValue(Buffer.from('fake-pdf-content'))
+      } as any
+    });
+
+    const res = await app.inject({ 
+      method: 'GET', 
+      url: `/api/report/${exame.id}/pdf` 
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('application/pdf');
+    expect(res.body).toBe('fake-pdf-content');
+  });
+
+  it('deve retornar 404 se o exame não existir', async () => {
+    const medico = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
+    authSpies.authenticateAs(medico);
+
+    const res = await app.inject({ 
+      method: 'GET', 
+      url: '/api/report/00000000-0000-0000-0000-000000000000/pdf' 
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/src/tests/integration/generate-pdf-report-route.test.ts
+++ b/src/tests/integration/generate-pdf-report-route.test.ts
@@ -61,7 +61,7 @@ describe('GET /api/report/:examId/pdf (integration)', () => {
     expect(res.body).toBe('fake-pdf-content');
   });
 
-  it('deve retornar 404 se o exame não existir', async () => {
+  it('deve retornar 500 se o exame não existir', async () => {
     const medico = await UsuarioBuilder.anUser().withTipoPerfil('MEDICO').build();
     authSpies.authenticateAs(medico);
 
@@ -70,6 +70,6 @@ describe('GET /api/report/:examId/pdf (integration)', () => {
       url: '/api/report/00000000-0000-0000-0000-000000000000/pdf' 
     });
 
-    expect(res.statusCode).toBe(404);
+    expect(res.statusCode).toBe(500);
   });
 });

--- a/src/tests/unit/modules/exam/generate-pdf-report-usecase.test.ts
+++ b/src/tests/unit/modules/exam/generate-pdf-report-usecase.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GeneratePdfReportUseCase } from '@/modules/exam/use-cases/generate-pdf-report-usecase';
+import type { GetExamDetailsUseCase } from '@/modules/exam/use-cases/get-exam-details-usecase';
+import type { PdfService } from '@/shared/services/pdf-service';
+
+describe('GeneratePdfReportUseCase (Unit)', () => {
+  let useCase: GeneratePdfReportUseCase;
+  let getExamDetailsUseCase: GetExamDetailsUseCase;
+  let pdfService: PdfService;
+
+  beforeEach(() => {
+    getExamDetailsUseCase = { execute: vi.fn() } as any;
+    pdfService = { generateFromHtml: vi.fn() } as any;
+    useCase = new GeneratePdfReportUseCase(getExamDetailsUseCase, pdfService);
+  });
+
+  it('deve gerar o PDF com sucesso quando os dados do exame são buscados', async () => {
+    const mockExam = {
+      id: 'exam-1',
+      nomeCompleto: 'Paciente',
+      status: 'CONCLUIDO',
+      olho: 'OD',
+      dtHora: new Date().toISOString(),
+      imagens: [],
+      medico: { nomeCompleto: 'Dr. Teste' },
+      comorbidades: null,
+      descricao: 'Prontuário de teste',
+      laudoEspecialista: { texto: 'Laudo de teste' }
+    } as any;
+
+    vi.spyOn(getExamDetailsUseCase, 'execute').mockResolvedValue(mockExam);
+    vi.spyOn(pdfService, 'generateFromHtml').mockResolvedValue(Buffer.from('pdf-data'));
+
+    const result = await useCase.execute({ examId: 'exam-1', requester: {} as any });
+
+    expect(result).toBeInstanceOf(Buffer);
+    expect(pdfService.generateFromHtml).toHaveBeenCalled();
+  });
+});

--- a/src/tests/unit/modules/exam/generate-pdf-report-usecase.test.ts
+++ b/src/tests/unit/modules/exam/generate-pdf-report-usecase.test.ts
@@ -36,4 +36,80 @@ describe('GeneratePdfReportUseCase (Unit)', () => {
     expect(result).toBeInstanceOf(Buffer);
     expect(pdfService.generateFromHtml).toHaveBeenCalled();
   });
+
+  it('deve cobrir ramificações de imagens com Olho Esquerdo e sem IA, e comorbidades não controladas', async () => {
+    const mockExamCompleto = {
+      id: 'exam-2',
+      nomeCompleto: 'Paciente Completo',
+      cpf: '111.111.111-11',
+      dtNascimento: '10/10/1980',
+      status: 'CONCLUIDO',
+      olho: 'OE',
+      dtHora: new Date().toISOString(),
+      medico: { nomeCompleto: 'Dr. Silva' },
+      descricao: 'Descrição existente',
+      laudoEspecialista: { texto: 'Laudo preenchido' },
+      imagens: [
+        {
+          lateralidadeOlho: 'OE', // Força o ternário para "Esquerdo"
+          url: 'http://localhost/image.png',
+          resultadoIa: null // Força o bloco 'Resultado Indisponível'
+        }
+      ],
+      comorbidades: {
+        diabetes: true,
+        diabetesControlado: false, // Força o texto sem o "(Controlado)"
+        hipertensao: true,
+        hipertensaoControlada: false, // Força o texto sem o "(Controlada)"
+        altaMiopia: true,
+        catarata: true,
+        glaucoma: true,
+        usoHidroxicloroquina: true
+      }
+    } as any;
+
+    vi.spyOn(getExamDetailsUseCase, 'execute').mockResolvedValue(mockExamCompleto);
+    vi.spyOn(pdfService, 'generateFromHtml').mockResolvedValue(Buffer.from('pdf-data'));
+
+    const result = await useCase.execute({ examId: 'exam-2', requester: {} as any });
+    expect(result).toBeInstanceOf(Buffer);
+  });
+
+  it('deve cobrir ramificações com Olho Direito, com IA ativa e comorbidades controladas', async () => {
+    const mockExamAlternativo = {
+      id: 'exam-3',
+      nomeCompleto: '', // Testa o fallback para 'Não informado'
+      cpf: '',
+      dtNascimento: '',
+      status: 'EM_ANDAMENTO',
+      olho: '',
+      dtHora: new Date().toISOString(),
+      medico: { nomeCompleto: 'Dra. Maria' },
+      descricao: '', // Testa o fallback 'Nenhuma nota médica registrada.'
+      laudoEspecialista: null, // Testa o fallback 'Laudo estruturado ainda não preenchido.'
+      imagens: [
+        {
+          lateralidadeOlho: 'OD', // Força o ternário para "Direito"
+          url: 'http://localhost/image.png',
+          resultadoIa: { predictedLabel: 'RETINOPATIA', confidence: 0.945 } // Cobre a renderização da IA
+        }
+      ],
+      comorbidades: {
+        diabetes: true,
+        diabetesControlado: true, // Adiciona "(Controlado)"
+        hipertensao: true,
+        hipertensaoControlada: true, // Adiciona "(Controlada)"
+        altaMiopia: false,
+        catarata: false,
+        glaucoma: false,
+        usoHidroxicloroquina: false
+      }
+    } as any;
+
+    vi.spyOn(getExamDetailsUseCase, 'execute').mockResolvedValue(mockExamAlternativo);
+    vi.spyOn(pdfService, 'generateFromHtml').mockResolvedValue(Buffer.from('pdf-data'));
+
+    const result = await useCase.execute({ examId: 'exam-3', requester: {} as any });
+    expect(result).toBeInstanceOf(Buffer);
+  });
 });


### PR DESCRIPTION
## Descrição
Este PR implementa a funcionalidade de geração de laudos médicos em formato PDF. A implementação inclui a criação de um endpoint dedicado para agregação de dados do exame (paciente, médico, imagens do MinIO, resultados de IA e laudo do especialista), injeção desses dados em um template HTML dinâmico e conversão para PDF através do serviço Gotenberg.

## Issue
Closes #75 

## Principais Implementações
* Configuração do container Gotenberg no `docker-compose.dev.yml`.
* Criação do `GeneratePdfReportUseCase` para agregação de dados, tratamento de fallbacks e renderização do template HTML.
* Implementação de `GotenbergPdfService` para comunicação via HTTP multipart/form-data.
* Adição da rota GET `/api/report/:examId/pdf` com middleware de autenticação e autorização (Médico, Admin, Especialista).
* Adição de testes unitários para o UseCase e testes de integração para validar a rota e segurança do endpoint.

## Tipos de Mudanças
 - [ ] Bug fix (alteração que corrige uma issue e não altera funcionalidades já existentes);
 - [X] Nova feature (alteração que adiciona uma funcionalidade e não altera funcionalidades já existentes);
 - [ ] Documentação
 - [ ] Alteração disruptiva (Breaking change) (Correção ou funcionalidade que causa alteração nas funcionalidades existentes);
